### PR TITLE
workaround for UniRef clusters without using edges

### DIFF
--- a/src/main/java/com/bio4j/model/uniprot/UniProtGraph.java
+++ b/src/main/java/com/bio4j/model/uniprot/UniProtGraph.java
@@ -2312,6 +2312,9 @@ public abstract class UniProtGraph<
 		public final mass mass = new mass();
 		public final version version = new version();
 		public final length length = new length();
+		public final uniRef100ClusterId uniRef100ClusterId = new uniRef100ClusterId();
+		public final uniRef90ClusterId uniRef90ClusterId = new uniRef90ClusterId();
+		public final uniRef50ClusterId uniRef50ClusterId = new uniRef50ClusterId();
 
 
         public ProteinType(RVT raw) {
@@ -2436,6 +2439,39 @@ public abstract class UniProtGraph<
 
 			public Class<Integer> valueClass() {
 				return Integer.class;
+			}
+		}
+		public final class uniRef100ClusterId
+				extends
+				UniProtVertexProperty<Protein<I, RV, RVT, RE, RET>, ProteinType, uniRef100ClusterId, String> {
+			public uniRef100ClusterId() {
+				super(ProteinType.this);
+			}
+
+			public Class<String> valueClass() {
+				return String.class;
+			}
+		}
+		public final class uniRef90ClusterId
+				extends
+				UniProtVertexProperty<Protein<I, RV, RVT, RE, RET>, ProteinType, uniRef90ClusterId, String> {
+			public uniRef90ClusterId() {
+				super(ProteinType.this);
+			}
+
+			public Class<String> valueClass() {
+				return String.class;
+			}
+		}
+		public final class uniRef50ClusterId
+				extends
+				UniProtVertexProperty<Protein<I, RV, RVT, RE, RET>, ProteinType, uniRef50ClusterId, String> {
+			public uniRef50ClusterId() {
+				super(ProteinType.this);
+			}
+
+			public Class<String> valueClass() {
+				return String.class;
 			}
 		}
 

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Protein.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Protein.java
@@ -66,6 +66,9 @@ public final class Protein <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, R
 	public Integer length() {
 		return get(type().length);
 	}
+	public String uniRef100ClusterId(){return get(type().uniRef100ClusterId);}
+	public String uniRef90ClusterId(){return get(type().uniRef90ClusterId);}
+	public String uniRef50ClusterId(){return get(type().uniRef50ClusterId);}
 
 	//////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/main/java/com/bio4j/model/uniprot_uniref/programs/ImportUniProtUniRef.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/programs/ImportUniProtUniRef.java
@@ -168,11 +168,9 @@ public abstract class ImportUniProtUniRef<I extends UntypedGraph<RV,RVT,RE,RET>,
 				entryStBuilder.delete(0, entryStBuilder.length());
 
 				ArrayList<String> membersAccessionList = new ArrayList<String>();
-				Element representativeMember = entryXMLElem.asJDomElement().getChild("representativeMember");
-				String representantAccession = getRepresentantAccession(representativeMember);
 				String entryId = entryXMLElem.asJDomElement().getAttributeValue("id");
 
-				if(entryId != null && representantAccession != null){
+				if(entryId != null){
 					//----obtaining cluster members---
 					List<Element> members = entryXMLElem.asJDomElement().getChildren("member");
 					for (Element member : members) {
@@ -186,11 +184,17 @@ public abstract class ImportUniProtUniRef<I extends UntypedGraph<RV,RVT,RE,RET>,
 						}
 					}
 					//----retrieving TitanProtein members----
-					List<Protein<I,RV,RVT,RE,RET>> proteinMembers = new LinkedList<>();
 					for (String proteinAccession : membersAccessionList){
 						Optional<Protein<I,RV,RVT,RE,RET>> optionalProtein = uniprotUniRefGraph.uniProtGraph().proteinAccessionIndex().getVertex(proteinAccession);
 						if(optionalProtein.isPresent()){
-							proteinMembers.add(optionalProtein.get());
+							Protein<I,RV,RVT,RE,RET> protein = optionalProtein.get();
+							if(unirefClusterNumber.equals("50")){
+								protein.set(uniprotUniRefGraph.uniProtGraph().Protein().uniRef50ClusterId, entryId);
+							}else if(unirefClusterNumber.equals("90")){
+								protein.set(uniprotUniRefGraph.uniProtGraph().Protein().uniRef90ClusterId, entryId);
+							}else if(unirefClusterNumber.equals("100")){
+								protein.set(uniprotUniRefGraph.uniProtGraph().Protein().uniRef100ClusterId, entryId);
+							}
 						}
 					}
 					//-----------------------------------------------------
@@ -199,22 +203,7 @@ public abstract class ImportUniProtUniRef<I extends UntypedGraph<RV,RVT,RE,RET>,
 						Optional<UniRef50Cluster<I,RV,RVT,RE,RET>> optionalCluster = uniprotUniRefGraph.uniRefGraph().uniRef50ClusterIdIndex().getVertex(entryId);
 						if(optionalCluster.isPresent()){
 							UniRef50Cluster<I,RV,RVT,RE,RET> cluster = optionalCluster.get();
-
-							Optional<Protein<I,RV,RVT,RE,RET>> optionalRepresentant = uniprotUniRefGraph.uniProtGraph().proteinAccessionIndex().getVertex(representantAccession);
-							if(optionalRepresentant.isPresent()){
-								Protein<I,RV,RVT,RE,RET> representant = optionalRepresentant.get();
-
-								UniRef50Member<I,RV,RVT,RE,RET> uniRef50Member = representant.addOutEdge(uniprotUniRefGraph.UniRef50Member(), cluster);
-								uniRef50Member.set(uniprotUniRefGraph.UniRef50Member().proteinAccession, representant.accession());
-
-								UniRef50Representant<I,RV,RVT,RE,RET> uniRef50Representant = representant.addOutEdge(uniprotUniRefGraph.UniRef50Representant(), cluster);
-								uniRef50Representant.set(uniprotUniRefGraph.UniRef50Representant().proteinAccession, representant.accession());
-							}
-							for (Protein<I,RV,RVT,RE,RET> protein : proteinMembers){
-								UniRef50Member<I,RV,RVT,RE,RET> uniRef50Member = protein.addOutEdge(uniprotUniRefGraph.UniRef50Member(), cluster);
-								uniRef50Member.set(uniprotUniRefGraph.UniRef50Member().proteinAccession, protein.accession());
-							}
-
+							cluster.set(uniprotUniRefGraph.uniRefGraph().UniRef50Cluster().members, membersAccessionList.toArray(new String[membersAccessionList.size()]));
 						}else{
 							logger.log(Level.INFO, (entryId + " cluster not found... :|"));
 						}
@@ -223,22 +212,7 @@ public abstract class ImportUniProtUniRef<I extends UntypedGraph<RV,RVT,RE,RET>,
 						Optional<UniRef90Cluster<I,RV,RVT,RE,RET>> optionalCluster = uniprotUniRefGraph.uniRefGraph().uniRef90ClusterIdIndex().getVertex(entryId);
 						if(optionalCluster.isPresent()){
 							UniRef90Cluster<I,RV,RVT,RE,RET> cluster = optionalCluster.get();
-
-							Optional<Protein<I,RV,RVT,RE,RET>> optionalRepresentant = uniprotUniRefGraph.uniProtGraph().proteinAccessionIndex().getVertex(representantAccession);
-							if(optionalRepresentant.isPresent()){
-								Protein<I,RV,RVT,RE,RET> representant = optionalRepresentant.get();
-
-								UniRef90Member<I,RV,RVT,RE,RET> uniRef90Member = representant.addOutEdge(uniprotUniRefGraph.UniRef90Member(), cluster);
-								uniRef90Member.set(uniprotUniRefGraph.UniRef90Member().proteinAccession, representant.accession());
-
-								UniRef90Representant<I,RV,RVT,RE,RET> uniRef90Representant = representant.addOutEdge(uniprotUniRefGraph.UniRef90Representant(), cluster);
-								uniRef90Representant.set(uniprotUniRefGraph.UniRef90Representant().proteinAccession, representant.accession());
-							}
-							for (Protein<I,RV,RVT,RE,RET> protein : proteinMembers){
-								UniRef90Member<I,RV,RVT,RE,RET> uniRef90Member = protein.addOutEdge(uniprotUniRefGraph.UniRef90Member(), cluster);
-								uniRef90Member.set(uniprotUniRefGraph.UniRef90Member().proteinAccession, protein.accession());
-							}
-
+							cluster.set(uniprotUniRefGraph.uniRefGraph().UniRef90Cluster().members, membersAccessionList.toArray(new String[membersAccessionList.size()]));
 						}else{
 							logger.log(Level.INFO, (entryId + " cluster not found... :|"));
 						}
@@ -247,22 +221,7 @@ public abstract class ImportUniProtUniRef<I extends UntypedGraph<RV,RVT,RE,RET>,
 						Optional<UniRef100Cluster<I,RV,RVT,RE,RET>> optionalCluster = uniprotUniRefGraph.uniRefGraph().uniRef100ClusterIdIndex().getVertex(entryId);
 						if(optionalCluster.isPresent()){
 							UniRef100Cluster<I,RV,RVT,RE,RET> cluster = optionalCluster.get();
-
-							Optional<Protein<I,RV,RVT,RE,RET>> optionalRepresentant = uniprotUniRefGraph.uniProtGraph().proteinAccessionIndex().getVertex(representantAccession);
-							if(optionalRepresentant.isPresent()){
-								Protein<I,RV,RVT,RE,RET> representant = optionalRepresentant.get();
-
-								UniRef100Member<I,RV,RVT,RE,RET> uniRef100Member = representant.addOutEdge(uniprotUniRefGraph.UniRef100Member(), cluster);
-								uniRef100Member.set(uniprotUniRefGraph.UniRef100Member().proteinAccession, representant.accession());
-
-								UniRef100Representant<I,RV,RVT,RE,RET> uniRef100Representant = representant.addOutEdge(uniprotUniRefGraph.UniRef100Representant(), cluster);
-								uniRef100Representant.set(uniprotUniRefGraph.UniRef100Representant().proteinAccession, representant.accession());
-							}
-							for (Protein<I,RV,RVT,RE,RET> protein : proteinMembers){
-								UniRef100Member<I,RV,RVT,RE,RET> uniRef100Member = protein.addOutEdge(uniprotUniRefGraph.UniRef100Member(), cluster);
-								uniRef100Member.set(uniprotUniRefGraph.UniRef100Member().proteinAccession, protein.accession());
-							}
-
+							cluster.set(uniprotUniRefGraph.uniRefGraph().UniRef100Cluster().members, membersAccessionList.toArray(new String[membersAccessionList.size()]));
 						}else{
 							logger.log(Level.INFO, (entryId + " cluster not found... :|"));
 						}

--- a/src/main/java/com/bio4j/model/uniprot_uniref/programs/ImportUniProtUniRef.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/programs/ImportUniProtUniRef.java
@@ -164,6 +164,7 @@ public abstract class ImportUniProtUniRef<I extends UntypedGraph<RV,RVT,RE,RET>,
 				entryStBuilder.append(line);
 
 				XMLElement entryXMLElem = new XMLElement(entryStBuilder.toString());
+				//freeing up memory
 				entryStBuilder.delete(0, entryStBuilder.length());
 
 				ArrayList<String> membersAccessionList = new ArrayList<String>();
@@ -270,6 +271,7 @@ public abstract class ImportUniProtUniRef<I extends UntypedGraph<RV,RVT,RE,RET>,
 
 
 			}
+
 
 			entryCounter++;
 			if ((entryCounter % limitForPrintingOut) == 0) {

--- a/src/main/java/com/bio4j/model/uniref/UniRefGraph.java
+++ b/src/main/java/com/bio4j/model/uniref/UniRefGraph.java
@@ -116,6 +116,8 @@ public abstract class UniRefGraph<
 		public final id id = new id();
 		public final name name = new name();
 		public final updatedDate updatedDate = new updatedDate();
+		public final representantAccession representantAccession = new representantAccession();
+		public final members members = new members();
 
 		public UniRef50ClusterType(RVT raw) { super(raw); }
 
@@ -150,6 +152,22 @@ public abstract class UniRefGraph<
 			public updatedDate() { super(UniRef50ClusterType.this); }
 			public Class<String> valueClass() { return String.class; }
 		}
+
+		public final class representantAccession
+				extends
+				UniRefVertexProperty<UniRef50Cluster<I, RV, RVT, RE, RET>, UniRef50ClusterType, representantAccession, String>
+		{
+			public representantAccession() { super(UniRef50ClusterType.this); }
+			public Class<String> valueClass() { return String.class; }
+		}
+
+		public final class members
+				extends
+				UniRefVertexProperty<UniRef50Cluster<I, RV, RVT, RE, RET>, UniRef50ClusterType, members, String[]>
+		{
+			public members() { super(UniRef50ClusterType.this); }
+			public Class<String[]> valueClass() { return String[].class; }
+		}
 	}
 
 	public final class UniRef90ClusterType
@@ -163,6 +181,8 @@ public abstract class UniRefGraph<
 		public final id id = new id();
 		public final name name = new name();
 		public final updatedDate updatedDate = new updatedDate();
+		public final representantAccession representantAccession = new representantAccession();
+		public final members members = new members();
 
 		public UniRef90ClusterType(RVT raw) { super(raw); }
 
@@ -199,6 +219,22 @@ public abstract class UniRefGraph<
 			public updatedDate() { super(UniRef90ClusterType.this); }
 			public Class<String> valueClass() { return String.class; }
 		}
+
+		public final class representantAccession
+				extends
+				UniRefVertexProperty<UniRef90Cluster<I, RV, RVT, RE, RET>, UniRef90ClusterType, representantAccession, String>
+		{
+			public representantAccession() { super(UniRef90ClusterType.this); }
+			public Class<String> valueClass() { return String.class; }
+		}
+
+		public final class members
+				extends
+				UniRefVertexProperty<UniRef90Cluster<I, RV, RVT, RE, RET>, UniRef90ClusterType, members, String[]>
+		{
+			public members() { super(UniRef90ClusterType.this); }
+			public Class<String[]> valueClass() { return String[].class; }
+		}
 	}
 
 	public final class UniRef100ClusterType
@@ -211,6 +247,8 @@ public abstract class UniRefGraph<
 		public final id id = new id();
 		public final name name = new name();
 		public final updatedDate updatedDate = new updatedDate();
+		public final representantAccession representantAccession = new representantAccession();
+		public final members members = new members();
 
 		public UniRef100ClusterType(RVT raw) { super(raw); }
 
@@ -245,6 +283,22 @@ public abstract class UniRefGraph<
 		{	
 			public updatedDate() { super(UniRef100ClusterType.this); }
 			public Class<String> valueClass() { return String.class; }
+		}
+
+		public final class representantAccession
+				extends
+				UniRefVertexProperty<UniRef100Cluster<I, RV, RVT, RE, RET>, UniRef100ClusterType, representantAccession, String>
+		{
+			public representantAccession() { super(UniRef100ClusterType.this); }
+			public Class<String> valueClass() { return String.class; }
+		}
+
+		public final class members
+				extends
+				UniRefVertexProperty<UniRef100Cluster<I, RV, RVT, RE, RET>, UniRef100ClusterType, members, String[]>
+		{
+			public members() { super(UniRef100ClusterType.this); }
+			public Class<String[]> valueClass() { return String[].class; }
 		}
 	}
 

--- a/src/main/java/com/bio4j/model/uniref/programs/ImportUniRef.java
+++ b/src/main/java/com/bio4j/model/uniref/programs/ImportUniRef.java
@@ -174,22 +174,27 @@ public abstract class ImportUniRef<I extends UntypedGraph<RV,RVT,RE,RET>,RV,RVT,
 				String entryId = entryXMLElem.asJDomElement().getAttributeValue("id");
 				String updatedDate = entryXMLElem.asJDomElement().getAttributeValue("updated");
 				String name = entryXMLElem.asJDomElement().getChildText("name");
+				Element representativeMember = entryXMLElem.asJDomElement().getChild("representativeMember");
+				String representantAccession = getRepresentantAccession(representativeMember);
 
 				if(unirefClusterNumber == 50){
 					UniRef50Cluster<I,RV,RVT,RE,RET> cluster = uniRefGraph.addVertex(uniRefGraph.UniRef50Cluster());
 					cluster.set(uniRefGraph.UniRef50Cluster().id, entryId);
 					cluster.set(uniRefGraph.UniRef50Cluster().updatedDate, updatedDate);
 					cluster.set(uniRefGraph.UniRef50Cluster().name, name);
+					cluster.set(uniRefGraph.UniRef50Cluster().representantAccession, representantAccession);
 				}else if(unirefClusterNumber == 90){
 					UniRef90Cluster<I,RV,RVT,RE,RET> cluster = uniRefGraph.addVertex(uniRefGraph.UniRef90Cluster());
 					cluster.set(uniRefGraph.UniRef90Cluster().id, entryId);
 					cluster.set(uniRefGraph.UniRef90Cluster().updatedDate, updatedDate);
 					cluster.set(uniRefGraph.UniRef90Cluster().name, name);
+					cluster.set(uniRefGraph.UniRef90Cluster().representantAccession, representantAccession);
 				}else if(unirefClusterNumber == 100){
 					UniRef100Cluster<I,RV,RVT,RE,RET> cluster = uniRefGraph.addVertex(uniRefGraph.UniRef100Cluster());
 					cluster.set(uniRefGraph.UniRef100Cluster().id, entryId);
 					cluster.set(uniRefGraph.UniRef100Cluster().updatedDate, updatedDate);
 					cluster.set(uniRefGraph.UniRef100Cluster().name, name);
+					cluster.set(uniRefGraph.UniRef100Cluster().representantAccession, representantAccession);
 				}
 
 			}

--- a/src/main/java/com/bio4j/model/uniref/vertices/UniRef100Cluster.java
+++ b/src/main/java/com/bio4j/model/uniref/vertices/UniRef100Cluster.java
@@ -38,6 +38,8 @@ public final class UniRef100Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, R
 	public String updatedDate() {
 		return get(type().updatedDate);
 	}
+	public String representantAccession() { return get(type().representantAccession);}
+	public String[] members() { return get(type().members);}
 
 	//////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/main/java/com/bio4j/model/uniref/vertices/UniRef50Cluster.java
+++ b/src/main/java/com/bio4j/model/uniref/vertices/UniRef50Cluster.java
@@ -38,6 +38,8 @@ public final class UniRef50Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, RV
 	public String updatedDate() {
 		return get(type().updatedDate);
 	}
+	public String representantAccession() { return get(type().representantAccession);}
+	public String[] members() { return get(type().members);}
 
 	//////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/main/java/com/bio4j/model/uniref/vertices/UniRef90Cluster.java
+++ b/src/main/java/com/bio4j/model/uniref/vertices/UniRef90Cluster.java
@@ -38,6 +38,8 @@ public final class UniRef90Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, RV
 	public String updatedDate() {
 		return get(type().updatedDate);
 	}
+	public String representantAccession() { return get(type().representantAccession);}
+	public String[] members() { return get(type().members);}
 
 	//////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
It's kind of a botched job but things should work when importing UniRef clusters and their relationship with Uniprot...

@eparejatobes any comments?