### PR TITLE
Remove redundant methods in vertices and edges

### DIFF
--- a/src/main/java/com/bio4j/model/enzymedb/vertices/Enzyme.java
+++ b/src/main/java/com/bio4j/model/enzymedb/vertices/Enzyme.java
@@ -1,45 +1,19 @@
 package com.bio4j.model.enzymedb.vertices;
 
 import com.bio4j.model.enzymedb.EnzymeDBGraph;
-import com.bio4j.model.uniprot.vertices.Protein;
-import com.bio4j.model.uniprot_enzymedb.edges.EnzymaticActivity;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Stream;
-
 public final class Enzyme<I extends UntypedGraph<RV,RVT,RE,RET>,RV,RVT,RE,RET>
-extends
-  EnzymeDBGraph.EnzymeDBVertex <
-  Enzyme<I,RV,RVT,RE,RET>,
-  EnzymeDBGraph<I,RV,RVT,RE,RET>.EnzymeType,
-  I,RV,RVT,RE,RET
-  >
+  extends
+    EnzymeDBGraph.EnzymeDBVertex <
+      Enzyme<I,RV,RVT,RE,RET>,
+      EnzymeDBGraph<I,RV,RVT,RE,RET>.EnzymeType,
+      I,RV,RVT,RE,RET
+    >
 {
 
   public Enzyme(RV vertex, EnzymeDBGraph<I,RV,RVT,RE,RET>.EnzymeType type) { super(vertex, type); }
 
   @Override
   public Enzyme<I,RV,RVT,RE,RET> self() { return this; }
-
-  // properties
-  public String id() { return get(type().id); }
-  public String[] cofactors() { return get(type().cofactors); }
-  public String officialName() { return get(type().officialName); }
-  public String[] alternateNames() { return get(type().alternateNames); }
-  public String comment() { return get(type().comment); }
-  public String catalyticActivity() { return get(type().catalyticActivity); }
-  public String[] prositeCrossReferences() { return get(type().prositeCrossReferences); }
-
-  //-----enzymaticActivity----
-  // incoming
-  public Optional<Stream<EnzymaticActivity<I,RV,RVT,RE,RET>>> enzymaticActivity_in() {
-
-    return inManyOptional(graph().uniProtEnzymeDBGraph().EnzymaticActivity());
-  }
-  public Optional<Stream<Protein<I,RV,RVT,RE,RET>>> enzymaticActivity_inV() {
-
-    return inManyOptionalV(graph().uniProtEnzymeDBGraph().EnzymaticActivity());
-  }
 }

--- a/src/main/java/com/bio4j/model/go/GoGraph.java
+++ b/src/main/java/com/bio4j/model/go/GoGraph.java
@@ -58,7 +58,7 @@ See [GO Ontology Relations](http://www.geneontology.org/GO.ontology.relations.sh
 - part of
 - has part of
 - regulates
-  - negatively regulates 
+  - negatively regulates
   - positively regulates
 
 */
@@ -82,17 +82,17 @@ implements
   public abstract UniProtGoGraph<I,RV,RVT,RE,RET> uniProtGoGraph();
 
   public abstract TypedVertexIndex.Unique <
-  GoTerm<I,RV,RVT,RE,RET>,GoTermType, 
-  GoTermType.id, String, 
-  GoGraph<I,RV,RVT,RE,RET>, 
+  GoTerm<I,RV,RVT,RE,RET>,GoTermType,
+  GoTermType.id, String,
+  GoGraph<I,RV,RVT,RE,RET>,
   I,RV,RVT,RE,RET
-  >  
+  >
   goTermIdIndex();
 
   public abstract TypedVertexIndex.Unique <
   SubOntologies<I,RV,RVT,RE,RET>, SubOntologiesType,
-  SubOntologiesType.name, String, 
-  GoGraph<I,RV,RVT,RE,RET>, 
+  SubOntologiesType.name, String,
+  GoGraph<I,RV,RVT,RE,RET>,
   I,RV,RVT,RE,RET
   >
   subontologiesNameIndex();
@@ -158,7 +158,7 @@ implements
   public final class id
   extends
     GoVertexProperty<GoTerm<I,RV,RVT,RE,RET>,GoTermType,id,String>
-  {  
+  {
     public id() { super(GoTermType.this); }
     public final Class<String> valueClass() { return String.class; }
   }
@@ -166,7 +166,7 @@ implements
   public final class name
   extends
     GoVertexProperty<GoTerm<I,RV,RVT,RE,RET>,GoTermType,name,String>
-  {  
+  {
     public name() { super(GoTermType.this); }
     public Class<String> valueClass() { return String.class; }
   }
@@ -174,7 +174,7 @@ implements
   public final class definition
   extends
     GoVertexProperty<GoTerm<I,RV,RVT,RE,RET>,GoTermType,definition,String>
-  {   
+  {
     public definition() { super(GoTermType.this); }
     public Class<String> valueClass() { return String.class; }
   }
@@ -198,7 +198,7 @@ implements
   public final class synonym
   extends
     GoVertexProperty<GoTerm<I,RV,RVT,RE,RET>,GoTermType,synonym,String>
-  {  
+  {
     public synonym() { super(GoTermType.this); }
     public Class<String> valueClass() { return String.class; }
   }
@@ -267,7 +267,7 @@ implements
   implements
   TypedEdge.Type.ManyToMany
   {
-  
+
   public HasPartOfType(RET raw) { super(GoGraph.this.GoTerm(), raw, GoGraph.this.GoTerm()); }
 
   @Override
@@ -314,7 +314,7 @@ implements
   public NegativelyRegulatesType value() { return graph().NegativelyRegulates(); }
 
   @Override
-  public NegativelyRegulates<I,RV,RVT,RE,RET> from(RE edge) { 
+  public NegativelyRegulates<I,RV,RVT,RE,RET> from(RE edge) {
 
     return new NegativelyRegulates<I,RV,RVT,RE,RET>(edge, this);
   }
@@ -337,7 +337,7 @@ implements
   public final PositivelyRegulatesType value() { return graph().PositivelyRegulates(); }
 
   @Override
-  public final PositivelyRegulates<I,RV,RVT,RE,RET> from(RE edge) { 
+  public final PositivelyRegulates<I,RV,RVT,RE,RET> from(RE edge) {
 
     return new PositivelyRegulates<I,RV,RVT,RE,RET>(edge, this);
   }
@@ -360,7 +360,7 @@ implements
   public final RegulatesType value() { return graph().Regulates(); }
 
   @Override
-  public final Regulates<I,RV,RVT,RE,RET> from(RE edge) { 
+  public final Regulates<I,RV,RVT,RE,RET> from(RE edge) {
 
     return new Regulates<I,RV,RVT,RE,RET>(edge, this);
   }
@@ -415,37 +415,38 @@ implements
   }
   }
 
-  public abstract static class GoVertex<
+  public abstract static class GoVertex <
     V extends GoVertex<V, VT, I,RV,RVT,RE,RET>,
     VT extends GoGraph<I,RV,RVT,RE,RET>.GoVertexType<V, VT>,
     I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT,RE,RET
-    >
+  >
     implements
-    TypedVertex<V, VT, GoGraph<I,RV,RVT,RE,RET>, I,RV,RVT,RE,RET> {
+      TypedVertex<V, VT, GoGraph<I,RV,RVT,RE,RET>, I,RV,RVT,RE,RET>
+  {
 
-  private RV vertex;
-  private VT type;
+    private final RV vertex;
+    private final VT type;
 
-  protected GoVertex(RV vertex, VT type) {
+    protected GoVertex(RV vertex, VT type) {
 
-    this.vertex = vertex;
-    this.type = type;
-  }
+      this.vertex = vertex;
+      this.type   = type;
+    }
 
-  @Override
-  public GoGraph<I,RV,RVT,RE,RET> graph() {
-    return type().graph();
-  }
+    @Override
+    public GoGraph<I,RV,RVT,RE,RET> graph() {
+      return type().graph();
+    }
 
-  @Override
-  public RV raw() {
-    return this.vertex;
-  }
+    @Override
+    public RV raw() {
+      return this.vertex;
+    }
 
-  @Override
-  public VT type() {
-    return type;
-  }
+    @Override
+    public VT type() {
+      return type;
+    }
   }
 
   abstract class GoVertexType<

--- a/src/main/java/com/bio4j/model/go/edges/HasPartOf.java
+++ b/src/main/java/com/bio4j/model/go/edges/HasPartOf.java
@@ -14,13 +14,8 @@ public final class HasPartOf<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, 
   >
 {
 
-  public HasPartOf(RE edge, GoGraph<I, RV, RVT, RE, RET>.HasPartOfType type) {
-
-    super(edge, type);
-  }
+  public HasPartOf(RE edge, GoGraph<I, RV, RVT, RE, RET>.HasPartOfType type) { super(edge, type); }
 
   @Override
-  public final HasPartOf<I, RV, RVT, RE, RET> self() {
-    return this;
-  }
+  public final HasPartOf<I, RV, RVT, RE, RET> self() { return this; }
 }

--- a/src/main/java/com/bio4j/model/go/edges/IsA.java
+++ b/src/main/java/com/bio4j/model/go/edges/IsA.java
@@ -6,21 +6,16 @@ import com.bio4j.angulillos.UntypedGraph;
 
 public final class IsA<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
   extends
-  GoGraph.GoEdge<
-    GoTerm<I, RV, RVT, RE, RET>, GoGraph<I, RV, RVT, RE, RET>.GoTermType,
-    IsA<I, RV, RVT, RE, RET>, GoGraph<I, RV, RVT, RE, RET>.IsAType,
-    GoTerm<I, RV, RVT, RE, RET>, GoGraph<I, RV, RVT, RE, RET>.GoTermType,
-    I, RV, RVT, RE, RET
-  >
+    GoGraph.GoEdge <
+      GoTerm<I, RV, RVT, RE, RET>, GoGraph<I, RV, RVT, RE, RET>.GoTermType,
+      IsA<I, RV, RVT, RE, RET>, GoGraph<I, RV, RVT, RE, RET>.IsAType,
+      GoTerm<I, RV, RVT, RE, RET>, GoGraph<I, RV, RVT, RE, RET>.GoTermType,
+      I, RV, RVT, RE, RET
+    >
 {
 
-  public IsA(RE edge, GoGraph<I, RV, RVT, RE, RET>.IsAType type) {
-
-    super(edge, type);
-  }
+  public IsA(RE edge, GoGraph<I, RV, RVT, RE, RET>.IsAType type) { super(edge, type); }
 
   @Override
-  public final IsA<I, RV, RVT, RE, RET> self() {
-    return this;
-  }
+  public final IsA<I, RV, RVT, RE, RET> self() { return this; }
 }

--- a/src/main/java/com/bio4j/model/go/vertices/GoSlims.java
+++ b/src/main/java/com/bio4j/model/go/vertices/GoSlims.java
@@ -1,20 +1,18 @@
 package com.bio4j.model.go.vertices;
 
 import com.bio4j.model.go.GoGraph;
-import com.bio4j.angulillos.*;
+import com.bio4j.angulillos.UntypedGraph;
 
 public final class GoSlims<I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT,RE,RET>
-extends GoGraph.GoVertex<
-  GoSlims<I,RV,RVT,RE,RET>,
-  GoGraph<I,RV,RVT,RE,RET>.GoSlimsType,
-  I,RV,RVT,RE,RET
->
+  extends
+    GoGraph.GoVertex <
+      GoSlims<I,RV,RVT,RE,RET>,
+      GoGraph<I,RV,RVT,RE,RET>.GoSlimsType,
+      I,RV,RVT,RE,RET
+    >
 {
 
-  public GoSlims(RV vertex, GoGraph<I,RV,RVT,RE,RET>.GoSlimsType type) {
-
-  super(vertex, type);
-  }
+  public GoSlims(RV vertex, GoGraph<I,RV,RVT,RE,RET>.GoSlimsType type) { super(vertex, type); }
 
   @Override
   public GoSlims<I,RV,RVT,RE,RET> self() { return this; }

--- a/src/main/java/com/bio4j/model/go/vertices/GoTerm.java
+++ b/src/main/java/com/bio4j/model/go/vertices/GoTerm.java
@@ -1,162 +1,19 @@
 package com.bio4j.model.go.vertices;
 
 import com.bio4j.model.go.GoGraph;
-import com.bio4j.model.go.edges.*;
-import com.bio4j.model.uniprot.vertices.Protein;
-import com.bio4j.model.uniprot_go.edges.GoAnnotation;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Stream;
-
 public final class GoTerm<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
-  extends GoGraph.GoVertex<
-  GoTerm<I, RV, RVT, RE, RET>,
-  GoGraph<I, RV, RVT, RE, RET>.GoTermType,
-  I, RV, RVT, RE, RET
-  >
+  extends
+    GoGraph.GoVertex <
+      GoTerm<I, RV, RVT, RE, RET>,
+      GoGraph<I, RV, RVT, RE, RET>.GoTermType,
+      I, RV, RVT, RE, RET
+    >
 {
 
-  public GoTerm(RV vertex, GoGraph<I, RV, RVT, RE, RET>.GoTermType type) {
-    super(vertex, type);
-  }
+  public GoTerm(RV vertex, GoGraph<I, RV, RVT, RE, RET>.GoTermType type) { super(vertex, type); }
 
   @Override
-  public final GoTerm<I, RV, RVT, RE, RET> self() {
-    return this;
-  }
-
-  public final String id() {
-    return get(type().id);
-  }
-
-  public final String name() {
-    return get(type().name);
-  }
-
-  public final String definition() {
-    return get(type().definition);
-  }
-
-  public final String comment() {
-    return get(type().comment);
-  }
-
-  public final String obsolete() {
-    return get(type().obsolete);
-  }
-
-  public final String synonym() {
-    return get(type().synonym);
-  }
-
-  public Optional<Stream<PartOf<I, RV, RVT, RE, RET>>> partOf_in() {
-    return inManyOptional(graph().PartOf());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> partOf_inV() {
-    return inManyOptionalV(graph().PartOf());
-  }
-
-  public Optional<Stream<PartOf<I, RV, RVT, RE, RET>>> partOf_out() {
-    return outManyOptional(graph().PartOf());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> partOf_outV() {
-    return outManyOptionalV(graph().PartOf());
-  }
-
-  public Optional<Stream<HasPartOf<I, RV, RVT, RE, RET>>> hasPartOf_in(){
-    return inManyOptional(graph().HasPartOf());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> hasPartOf_inV(){
-    return inManyOptionalV(graph().HasPartOf());
-  }
-  public Optional<Stream<HasPartOf<I, RV, RVT, RE, RET>>> hasPartOf_out(){
-    return outManyOptional(graph().HasPartOf());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> hasPartOf_outV(){
-    return outManyOptionalV(graph().HasPartOf());
-  }
-
-  public Optional<Stream<Regulates<I, RV, RVT, RE, RET>>> regulates_in(){
-    return inManyOptional(graph().Regulates());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> regulates_inV(){
-    return inManyOptionalV(graph().Regulates());
-  }
-  public Optional<Stream<Regulates<I, RV, RVT, RE, RET>>> regulates_out(){
-    return outManyOptional(graph().Regulates());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> regulates_outV(){
-    return outManyOptionalV(graph().Regulates());
-  }
-
-  public Optional<Stream<PositivelyRegulates<I, RV, RVT, RE, RET>>> positivelyRegulates_in(){
-    return inManyOptional(graph().PositivelyRegulates());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> positivelyRegulates_inV(){
-    return inManyOptionalV(graph().PositivelyRegulates());
-  }
-  public Optional<Stream<PositivelyRegulates<I, RV, RVT, RE, RET>>> positivelyRegulates_out(){
-    return outManyOptional(graph().PositivelyRegulates());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> positivelyRegulates_outV(){
-    return outManyOptionalV(graph().PositivelyRegulates());
-  }
-
-  //----negatively regulates-------
-  public Optional<Stream<NegativelyRegulates<I, RV, RVT, RE, RET>>> negativelyRegulates_in(){
-    return inManyOptional(graph().NegativelyRegulates());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> negativelyRegulates_inV(){
-    return inManyOptionalV(graph().NegativelyRegulates());
-  }
-  public Optional<Stream<NegativelyRegulates<I, RV, RVT, RE, RET>>> negaitivelyRegulates_out(){
-    return outManyOptional(graph().NegativelyRegulates());
-  }
-
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> negativelyRegulates_outV(){
-    return outManyOptionalV(graph().NegativelyRegulates());
-  }
-
-  //----is a-------
-  public Optional<Stream<IsA<I, RV, RVT, RE, RET>>> isA_in(){
-    return inManyOptional(graph().IsA());
-  }
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> isA_inV(){
-    return inManyOptionalV(graph().IsA());
-  }
-
-  public Optional<Stream<IsA<I, RV, RVT, RE, RET>>> isA_out(){
-    return outManyOptional(graph().IsA());
-  }
-  public Optional<Stream<GoTerm<I, RV, RVT, RE, RET>>> isA_outV(){
-    return outManyOptionalV(graph().IsA());
-  }
-
-  //-----subontology-----
-  public SubOntology<I, RV, RVT, RE, RET> subontoloty_out(){
-    return outOne(graph().SubOntology());
-  }
-  //-----subontology-----
-  public SubOntologies<I, RV, RVT, RE, RET> subontoloty_outV(){
-    return outOneV(graph().SubOntology());
-  }
-
-  public Optional<Stream<GoAnnotation<I, RV, RVT, RE, RET>>> goAnnotation_in() {
-    return inManyOptional( graph().uniProtGoGraph().GoAnnotation() );
-  }
-
-  public Optional<Stream<Protein<I, RV, RVT, RE, RET>>> goAnnotation_inV(){
-    return inManyOptionalV(graph().uniProtGoGraph().GoAnnotation());
-  }
+  public final GoTerm<I, RV, RVT, RE, RET> self() { return this; }
 }

--- a/src/main/java/com/bio4j/model/go/vertices/SubOntologies.java
+++ b/src/main/java/com/bio4j/model/go/vertices/SubOntologies.java
@@ -1,39 +1,19 @@
 package com.bio4j.model.go.vertices;
 
 import com.bio4j.model.go.GoGraph;
-import com.bio4j.angulillos.*;
-import com.bio4j.model.go.edges.SubOntology;
+import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
- * Rels into this singleton node represent subontologies.
- *
- * @author <a href="mailto:ppareja@era7.com">Pablo Pareja Tobes</a>
- * @author <a href="mailto:eparejatobes@ohnosequences.com">Eduardo Pareja-Tobes</a>
- */
 public final class SubOntologies<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
-  extends GoGraph.GoVertex<
-    SubOntologies<I, RV, RVT, RE, RET>,
-    GoGraph<I, RV, RVT, RE, RET>.SubOntologiesType,
-    I, RV, RVT, RE, RET
-  >
+  extends
+    GoGraph.GoVertex <
+      SubOntologies<I, RV, RVT, RE, RET>,
+      GoGraph<I, RV, RVT, RE, RET>.SubOntologiesType,
+      I, RV, RVT, RE, RET
+    >
 {
 
-  public SubOntologies(RV vertex, GoGraph<I, RV, RVT, RE, RET>.SubOntologiesType type) {
-
-    super(vertex, type);
-  }
+  public SubOntologies(RV vertex, GoGraph<I, RV, RVT, RE, RET>.SubOntologiesType type) { super(vertex, type); }
 
   @Override
-  public final SubOntologies<I, RV, RVT, RE, RET> self() {
-    return this;
-  }
-
-  public Stream<SubOntology<I, RV, RVT, RE, RET>> subontoloty_in(){
-    return inMany(graph().SubOntology());
-  }
-  public Stream<GoTerm<I, RV, RVT, RE, RET>> subontoloty_inV(){
-    return inManyV(graph().SubOntology());
-  }
+  public final SubOntologies<I, RV, RVT, RE, RET> self() { return this; }
 }

--- a/src/main/java/com/bio4j/model/ncbiTaxonomy/edges/NCBITaxonParent.java
+++ b/src/main/java/com/bio4j/model/ncbiTaxonomy/edges/NCBITaxonParent.java
@@ -6,21 +6,16 @@ import com.bio4j.angulillos.UntypedGraph;
 
 public final class NCBITaxonParent<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
   extends
-  NCBITaxonomyGraph.NCBITaxonomyEdge<
-    NCBITaxon<I, RV, RVT, RE, RET>, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonType,
-    NCBITaxonParent<I, RV, RVT, RE, RET>, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonParentType,
-    NCBITaxon<I, RV, RVT, RE, RET>, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonType,
-    I, RV, RVT, RE, RET
-  >
+    NCBITaxonomyGraph.NCBITaxonomyEdge <
+      NCBITaxon<I, RV, RVT, RE, RET>, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonType,
+      NCBITaxonParent<I, RV, RVT, RE, RET>, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonParentType,
+      NCBITaxon<I, RV, RVT, RE, RET>, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonType,
+      I, RV, RVT, RE, RET
+    >
 {
 
-  public NCBITaxonParent(RE edge, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonParentType type) {
-
-    super(edge, type);
-  }
+  public NCBITaxonParent(RE edge, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonParentType type) { super(edge, type); }
 
   @Override
-  public final NCBITaxonParent<I, RV, RVT, RE, RET> self() {
-    return this;
-  }
+  public final NCBITaxonParent<I, RV, RVT, RE, RET> self() { return this; }
 }

--- a/src/main/java/com/bio4j/model/ncbiTaxonomy/vertices/NCBITaxon.java
+++ b/src/main/java/com/bio4j/model/ncbiTaxonomy/vertices/NCBITaxon.java
@@ -11,54 +11,16 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 public final class NCBITaxon<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
-extends
-  NCBITaxonomyGraph.NCBITaxonomyVertex<
-    NCBITaxon<I, RV, RVT, RE, RET>,
-    NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonType,
-    I, RV, RVT, RE, RET
-  >
+  extends
+    NCBITaxonomyGraph.NCBITaxonomyVertex <
+      NCBITaxon<I, RV, RVT, RE, RET>,
+      NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonType,
+      I, RV, RVT, RE, RET
+    >
 {
 
-  public NCBITaxon(RV vertex, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonType type) {
-    super(vertex, type);
-  }
+  public NCBITaxon(RV vertex, NCBITaxonomyGraph<I, RV, RVT, RE, RET>.NCBITaxonType type) { super(vertex, type); }
 
   @Override
-  public final NCBITaxon<I, RV, RVT, RE, RET> self() {
-  return this;
-  }
-
-  // properties
-  public final String id() {
-    return get(type().id);
-  }
-
-  public final String name() {
-    return get(type().name);
-  }
-
-  public final String taxonomicRank() {
-    return get(type().taxonomicRank);
-  }
-
-  public final Optional<NCBITaxonParent<I, RV, RVT, RE, RET>> ncbiTaxonParent_in() {
-    return inOneOptional(graph().NCBITaxonParent());
-  }
-  public final Optional<NCBITaxon<I, RV, RVT, RE, RET>> ncbiTaxonParent_inV() {
-    return inOneOptionalV(graph().NCBITaxonParent());
-  }
-
-  public final Optional<Stream<NCBITaxonParent<I, RV, RVT, RE, RET>>> ncbiTaxonParent_out() {
-    return outManyOptional(graph().NCBITaxonParent());
-  }
-  public final Optional<Stream<NCBITaxon<I, RV, RVT, RE, RET>>> ncbiTaxonParent_outV() {
-    return outManyOptionalV(graph().NCBITaxonParent());
-  }
-
-  public final Optional<Stream<ProteinNCBITaxon<I, RV, RVT, RE, RET>>> proteinNCBITaxon_in() {
-    return inManyOptional(graph().uniProtNCBITaxonomyGraph().ProteinNCBITaxon());
-  }
-  public final Optional<Stream<Protein<I, RV, RVT, RE, RET>>> proteinNCBITaxon_inV() {
-    return inManyOptionalV(graph().uniProtNCBITaxonomyGraph().ProteinNCBITaxon());
-  }
+  public final NCBITaxon<I, RV, RVT, RE, RET> self() { return this; }
 }

--- a/src/main/java/com/bio4j/model/uniprot/edges/ArticleJournal.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/ArticleJournal.java
@@ -22,15 +22,6 @@ I, RV, RVT, RE, RET
     super(edge, type);
   }
 
-  // properties
-  public String volume() {
-    return get(type().volume);
-  }
-  public String first() {  return get(type().first);  }
-  public String last() {
-    return get(type().last);
-  }
-
   @Override
   public ArticleJournal<I, RV, RVT, RE, RET> self() {
     return this;

--- a/src/main/java/com/bio4j/model/uniprot/edges/OnlineArticleOnlineJournal.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/OnlineArticleOnlineJournal.java
@@ -22,11 +22,6 @@ I, RV, RVT, RE, RET
     super(edge, type);
   }
 
-  // properties
-  public String locator() {
-    return get(type().locator);
-  }
-
   @Override
   public OnlineArticleOnlineJournal<I, RV, RVT, RE, RET> self() {
     return this;

--- a/src/main/java/com/bio4j/model/uniprot/edges/ProteinComment.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/ProteinComment.java
@@ -17,51 +17,6 @@ CommentType<I, RV, RVT, RE, RET>, UniProtGraph<I, RV, RVT, RE, RET>.CommentTypeT
 I, RV, RVT, RE, RET
 > {
 
-  // properties
-  public String position() {
-    return get(type().position);
-  }
-  public String mass() {  return get(type().mass);  }
-  public String evidence() {
-    return get(type().evidence);
-  }
-  public String method() {
-    return get(type().method);
-  }
-  public int begin() {
-    return get(type().begin);
-  }
-  public int end() {
-    return get(type().end);
-  }
-  public String status() {
-    return get(type().status);
-  }
-  public String text() {
-    return get(type().text);
-  }
-  public String temperatureDependence() {
-    return get(type().temperatureDependence);
-  }
-  public String phDependence() {
-    return get(type().phDependence);
-  }
-  public String kineticsXML() {
-    return get(type().kineticsXML);
-  }
-  public String absorptionMax() {
-    return get(type().absorptionMax);
-  }
-  public String absorptionText() {
-    return get(type().absorptionText);
-  }
-  public String redoxPotential() {
-    return get(type().redoxPotential);
-  }
-  public String redoxPotentialEvidence() {
-    return get(type().redoxPotentialEvidence);
-  }
-
   public ProteinComment(RE edge, UniProtGraph<I, RV, RVT, RE, RET>.ProteinCommentType type) {
 
     super(edge, type);

--- a/src/main/java/com/bio4j/model/uniprot/edges/ProteinDisease.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/ProteinDisease.java
@@ -17,16 +17,6 @@ Disease<I, RV, RVT, RE, RET>, UniProtGraph<I, RV, RVT, RE, RET>.DiseaseType,
 I, RV, RVT, RE, RET
 > {
 
-  public String status() {
-    return get(type().status);
-  }
-  public String text() {
-    return get(type().text);
-  }
-  public String evidence() {
-    return get(type().evidence);
-  }
-
   public ProteinDisease(RE edge, UniProtGraph<I, RV, RVT, RE, RET>.ProteinDiseaseType type) {
 
     super(edge, type);

--- a/src/main/java/com/bio4j/model/uniprot/edges/ProteinFeature.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/ProteinFeature.java
@@ -21,34 +21,6 @@ I, RV, RVT, RE, RET
     super(edge, type);
   }
 
-  // properties
-  public String description() {
-    return get(type().description);
-  }
-  public String id() {  return get(type().id);  }
-  public String evidence() {
-    return get(type().evidence);
-  }
-  public String status() {
-    return get(type().status);
-  }
-  public int begin() {
-    return get(type().begin);
-  }
-  public int end() {
-    return get(type().end);
-  }
-  public String original() {
-    return get(type().original);
-  }
-  public String variation() {
-    return get(type().variation);
-  }
-  public String ref() {
-    return get(type().ref);
-  }
-
-
   @Override
   public ProteinFeature<I, RV, RVT, RE, RET> self() {
     return this;

--- a/src/main/java/com/bio4j/model/uniprot/edges/ProteinGeneLocation.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/ProteinGeneLocation.java
@@ -26,7 +26,6 @@ I, RV, RVT, RE, RET
     return get(type().name);
   }
 
-
   @Override
   public ProteinGeneLocation<I, RV, RVT, RE, RET> self() {
     return this;

--- a/src/main/java/com/bio4j/model/uniprot/edges/ProteinSequenceCaution.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/ProteinSequenceCaution.java
@@ -17,25 +17,6 @@ SequenceCaution<I, RV, RVT, RE, RET>, UniProtGraph<I, RV, RVT, RE, RET>.Sequence
 I, RV, RVT, RE, RET
 > {
 
-  // properties
-  public String id() {  return get(type().id);  }
-  public String evidence() {
-    return get(type().evidence);
-  }
-  public String status() {
-    return get(type().status);
-  }
-  public String text() {
-    return get(type().text);
-  }
-  public String resource() {
-    return get(type().resource);
-  }
-  public String version() {
-    return get(type().version);
-  }
-  public String position() {  return get(type().position);}
-
   public ProteinSequenceCaution(RE edge, UniProtGraph<I, RV, RVT, RE, RET>.ProteinSequenceCautionType type) {
 
     super(edge, type);

--- a/src/main/java/com/bio4j/model/uniprot/edges/ProteinSubcellularLocation.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/ProteinSubcellularLocation.java
@@ -17,16 +17,6 @@ SubcellularLocation<I, RV, RVT, RE, RET>, UniProtGraph<I, RV, RVT, RE, RET>.Subc
 I, RV, RVT, RE, RET
 > {
 
-  // properties
-  public String status() {
-    return get(type().status);
-  }
-  public String topology() {  return get(type().topology);  }
-  public String topologyStatus() {  return get(type().topologyStatus);  }
-  public String evidence() {
-    return get(type().evidence);
-  }
-
   public ProteinSubcellularLocation(RE edge, UniProtGraph<I, RV, RVT, RE, RET>.ProteinSubcellularLocationType type) {
 
     super(edge, type);

--- a/src/main/java/com/bio4j/model/uniprot/edges/ReferenceBook.java
+++ b/src/main/java/com/bio4j/model/uniprot/edges/ReferenceBook.java
@@ -17,18 +17,6 @@ Book<I, RV, RVT, RE, RET>, UniProtGraph<I, RV, RVT, RE, RET>.BookType,
 I, RV, RVT, RE, RET
 > {
 
-  // properties
-  public String title() {
-    return get(type().title);
-  }
-  public int first() {  return get(type().first);  }
-  public int last() {
-    return get(type().last);
-  }
-  public String volume() {
-    return get(type().volume);
-  }
-
   public ReferenceBook(RE edge, UniProtGraph<I, RV, RVT, RE, RET>.ReferenceBookType type) {
 
     super(edge, type);

--- a/src/main/java/com/bio4j/model/uniprot/programs/ImportUniProtEdges.java
+++ b/src/main/java/com/bio4j/model/uniprot/programs/ImportUniProtEdges.java
@@ -426,10 +426,10 @@ public abstract class ImportUniProtEdges<I extends UntypedGraph<RV,RVT,RE,RET>,R
                   if(tempLocationOptional.isPresent()){
                     SubcellularLocation<I,RV,RVT,RE,RET> tempLocation = tempLocationOptional.get();
 
-                    if(!subcellularLocationParentEdgesAlreadyCreated.contains(tempLocation.name())){
-                      subcellularLocationParentEdgesAlreadyCreated.add(tempLocation.name());
+                    if(!subcellularLocationParentEdgesAlreadyCreated.contains(tempLocation.get(tempLocation.type().name))){
+                      subcellularLocationParentEdgesAlreadyCreated.add(tempLocation.get(tempLocation.type().name));
                       try{
-                        tempLocation.subcellularLocationParent_out();
+                        tempLocation.outV(graph.SubcellularLocationParent());
                       }catch (NoSuchElementException e){
                         tempLocation.addOutEdge(graph.SubcellularLocationParent(), lastLocation);
                       }
@@ -739,7 +739,7 @@ public abstract class ImportUniProtEdges<I extends UntypedGraph<RV,RVT,RE,RET>,R
     //   }
     // }
   }
-  
+
   private void importProteinCitations(
   Element entryXMLElem,
   UniProtGraph<I,RV,RVT,RE,RET> graph,

--- a/src/main/java/com/bio4j/model/uniprot/vertices/AlternativeProduct.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/AlternativeProduct.java
@@ -1,47 +1,19 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.IsoformEventGenerator;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 10/7/2014.
-*/
 public class AlternativeProduct <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
-extends UniProtGraph.UniProtVertex<
-AlternativeProduct<I, RV, RVT, RE, RET>,
-UniProtGraph<I, RV, RVT, RE, RET>.AlternativeProductType,
-I, RV, RVT, RE, RET
-> {
+  extends
+    UniProtGraph.UniProtVertex<
+      AlternativeProduct<I, RV, RVT, RE, RET>,
+      UniProtGraph<I, RV, RVT, RE, RET>.AlternativeProductType,
+      I, RV, RVT, RE, RET
+    >
+{
 
-  public AlternativeProduct(RV vertex, UniProtGraph<I, RV, RVT, RE, RET>.AlternativeProductType type) {
-    super(vertex, type);
-  }
+  public AlternativeProduct(RV vertex, UniProtGraph<I, RV, RVT, RE, RET>.AlternativeProductType type) { super(vertex, type); }
 
   @Override
-  public AlternativeProduct<I, RV, RVT, RE, RET> self() {
-    return this;
-  }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // IsoformEventGenerator
-  // ingoing
-  public Stream<IsoformEventGenerator<I, RV, RVT, RE, RET>> isoformEventGenerator_in(){
-    return inMany(graph().IsoformEventGenerator());
-  }
-  public Stream<Isoform<I, RV, RVT, RE, RET>> isoformEventGenerator_inV(){
-    return inManyV(graph().IsoformEventGenerator());
-  }
-
-
+  public AlternativeProduct<I, RV, RVT, RE, RET> self() { return this; }
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Article.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Article.java
@@ -1,67 +1,19 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ArticleJournal;
-import com.bio4j.model.uniprot.edges.ArticlePubmed;
-import com.bio4j.model.uniprot.edges.ReferenceArticle;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.Optional;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Article <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
-extends UniProtGraph.UniProtVertex<
-Article<I, RV, RVT, RE, RET>,
-UniProtGraph<I, RV, RVT, RE, RET>.ArticleType,
-I, RV, RVT, RE, RET
->  {
+  extends
+    UniProtGraph.UniProtVertex <
+      Article<I, RV, RVT, RE, RET>,
+      UniProtGraph<I, RV, RVT, RE, RET>.ArticleType,
+      I, RV, RVT, RE, RET
+    >
+{
 
-  public Article(RV vertex, UniProtGraph<I, RV, RVT, RE, RET>.ArticleType type) {
-    super(vertex, type);
-  }
+  public Article(RV vertex, UniProtGraph<I, RV, RVT, RE, RET>.ArticleType type) { super(vertex, type); }
 
   @Override
-  public Article<I, RV, RVT, RE, RET> self() {
-    return this;
-  }
-
-  // properties
-  public String title() {
-    return get(type().title);
-  }
-
-  public String doId() {
-    return get(type().doId);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // articlePubmed
-  // outgoing
-  public Optional<ArticlePubmed<I, RV, RVT, RE, RET>> articlePubmed_out(){
-    return outOneOptional(graph().ArticlePubmed());
-  }
-  public Optional<Pubmed<I, RV, RVT, RE, RET>> articlePubmed_outV(){
-    return outOneOptionalV(graph().ArticlePubmed());
-  }
-  // referenceArticle
-  // ingoing
-  public ReferenceArticle<I, RV, RVT, RE, RET> referenceArticle_in(){
-    return inOne(graph().ReferenceArticle());
-  }
-  public Reference<I, RV, RVT, RE, RET> referenceArticle_inV(){
-    return inOneV(graph().ReferenceArticle());
-  }
-  // articleJournal
-  // outgoing
-  public Optional<ArticleJournal<I, RV, RVT, RE, RET>> articleJournal_out(){
-    return outOneOptional(graph().ArticleJournal());
-  }
-  public Optional<Journal<I, RV, RVT, RE, RET>> articleJournal_outV(){
-    return outOneOptionalV(graph().ArticleJournal());
-  }
+  public Article<I, RV, RVT, RE, RET> self() { return this; }
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Book.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Book.java
@@ -1,16 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.BookCity;
-import com.bio4j.model.uniprot.edges.BookPublisher;
-import com.bio4j.model.uniprot.edges.ReferenceBook;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.Optional;
-
-/**
-* @author <a href="mailto:ppareja@era7.com">Pablo Pareja Tobes</a>
-*/
 public final class Book<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Book<I, RV, RVT, RE, RET>,
@@ -25,41 +17,5 @@ I, RV, RVT, RE, RET
   @Override
   public Book<I, RV, RVT, RE, RET> self() {
     return this;
-  }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  //referenceBook
-  // ingoing
-  public ReferenceBook<I, RV, RVT, RE, RET> referenceBook_in(){
-    return inOne(graph().ReferenceBook());
-  }
-  public Reference<I, RV, RVT, RE, RET> referenceBook_inV(){
-    return inOneV(graph().ReferenceBook());
-  }
-
-  // bookCity
-  // outgoing
-  public Optional<BookCity<I, RV, RVT, RE, RET>> bookCity_out(){
-    return outOneOptional(graph().BookCity());
-  }
-  public Optional<City<I, RV, RVT, RE, RET>> bookCity_outV(){
-    return outOneOptionalV(graph().BookCity());
-  }
-
-  // bookPublisher
-  // outgoing
-  public Optional<BookPublisher<I, RV, RVT, RE, RET>> bookPublisher_out(){
-    return outOneOptional(graph().BookPublisher());
-  }
-  public Optional<Publisher<I, RV, RVT, RE, RET>> bookPublisher_outV(){
-    return outOneOptionalV(graph().BookPublisher());
   }
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/City.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/City.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.BookCity;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class City <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 City<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public City<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // bookCity
-  // ingoing
-  public Stream<BookCity<I, RV, RVT, RE, RET>> bookCity_in(){
-    return inMany(graph().BookCity());
-  }
-  public Stream<Book<I, RV, RVT, RE, RET>> bookCity_inV(){
-    return inManyV(graph().BookCity());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/CommentType.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/CommentType.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinComment;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* @author <a href="mailto:ppareja@era7.com">Pablo Pareja Tobes</a>
-*/
 public final class CommentType <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 CommentType<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public CommentType<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinComment
-  // ingoing
-  public Stream<ProteinComment<I, RV, RVT, RE, RET>> proteinComment_in(){
-    return inMany(graph().ProteinComment());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinComment_inV(){
-    return inManyV(graph().ProteinComment());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Consortium.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Consortium.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ReferenceAuthorConsortium;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Consortium <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Consortium<I, RV, RVT, RE, RET>,
@@ -24,23 +18,4 @@ I, RV, RVT, RE, RET
   public Consortium<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // referenceAuthorConsortium
-  // ingoing
-  public Stream<ReferenceAuthorConsortium<I, RV, RVT, RE, RET>> referenceAuthorConsortium_in(){
-    return inMany(graph().ReferenceAuthorConsortium());
-  }
-  public Stream<Reference<I, RV, RVT, RE, RET>> referenceAuthorConsortium_inNodes(){
-    return inManyV(graph().ReferenceAuthorConsortium());
-  }
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Country.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Country.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.InstituteCountry;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Country <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Country<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public Country<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // instituteCountry
-  // ingoing
-  public Stream<InstituteCountry<I, RV, RVT, RE, RET>> instituteCountry_in(){
-    return inMany(graph().InstituteCountry());
-  }
-  public Stream<Institute<I, RV, RVT, RE, RET>> instituteCountry_inV(){
-    return inManyV(graph().InstituteCountry());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/DB.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/DB.java
@@ -1,20 +1,15 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.SubmissionDB;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class DB <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 DB<I, RV, RVT, RE, RET>,
 UniProtGraph<I, RV, RVT, RE, RET>.DBType,
 I, RV, RVT, RE, RET
-> {
+>
+{
 
   public DB(RV vertex, UniProtGraph<I, RV, RVT, RE, RET>.DBType type) {
     super(vertex, type);
@@ -24,24 +19,4 @@ I, RV, RVT, RE, RET
   public DB<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // submissionDB
-  // ingoing
-  public Stream<SubmissionDB<I, RV, RVT, RE, RET>> submissionDB_in(){
-    return inMany(graph().SubmissionDB());
-  }
-  public Stream<Submission<I, RV, RVT, RE, RET>> submissionDB_inV(){
-    return inManyV(graph().SubmissionDB());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Disease.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Disease.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinDisease;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Disease <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Disease<I, RV, RVT, RE, RET>,
@@ -24,31 +18,4 @@ I, RV, RVT, RE, RET
   public Disease<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-  public String id() {
-    return get(type().id);
-  }
-  public String acronym() {
-    return get(type().acronym);
-  }
-  public String description() { return get(type().description);}
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinDisease
-  // ingoing
-  public Stream<ProteinDisease<I, RV, RVT, RE, RET>> proteinDisease_in(){
-    return inMany(graph().ProteinDisease());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>>  proteinDisease_inV(){
-    return inManyV(graph().ProteinDisease());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/EMBL.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/EMBL.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinEMBL;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class EMBL <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 EMBL<I, RV, RVT, RE, RET>,
@@ -24,30 +18,4 @@ I, RV, RVT, RE, RET
   public EMBL<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String proteinSequenceId() {
-    return get(type().proteinSequenceId);
-  }
-  public String moleculeType() {
-    return get(type().moleculeType);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinEMBL
-  // ingoing
-  public Stream<ProteinEMBL<I, RV, RVT, RE, RET>> proteinEMBL_in(){
-    return inMany(graph().ProteinEMBL());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinEMBL_inV(){
-    return inManyV(graph().ProteinEMBL());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Ensembl.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Ensembl.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinEnsembl;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/29/2014.
-*/
 public final class Ensembl <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Ensembl<I, RV, RVT, RE, RET>,
@@ -24,33 +18,4 @@ I, RV, RVT, RE, RET
   public Ensembl<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String proteinSequenceId() {
-    return get(type().proteinSequenceId);
-  }
-  public String moleculeId() {
-    return get(type().moleculeId);
-  }
-  public String geneId() {
-    return get(type().geneId);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinEnsembl
-  // ingoing
-  public Stream<ProteinEnsembl<I, RV, RVT, RE, RET>> proteinEnsembl_in(){
-    return inMany(graph().ProteinEnsembl());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinEnsembl_inV(){
-    return inManyV(graph().ProteinEnsembl());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/FeatureType.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/FeatureType.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinFeature;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class FeatureType <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 FeatureType<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public FeatureType<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinFeature
-  // ingoing
-  public Stream<ProteinFeature<I, RV, RVT, RE, RET>> proteinFeature_in(){
-    return inMany(graph().ProteinFeature());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinFeature_inV(){
-    return inManyV(graph().ProteinFeature());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/GeneLocation.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/GeneLocation.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinGeneLocation;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* @author <a href="mailto:ppareja@era7.com">Pablo Pareja Tobes</a>
-*/
 public final class GeneLocation <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 GeneLocation<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public GeneLocation<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinGeneLocation
-  // ingoing
-  public Stream<ProteinGeneLocation<I, RV, RVT, RE, RET>> proteinGeneLocation_in(){
-    return inMany(graph().ProteinGeneLocation());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinGeneLocation_inV(){
-    return inManyV(graph().ProteinGeneLocation());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Institute.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Institute.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ThesisInstitute;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Institute <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Institute<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public Institute<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // thesisInstitute
-  // ingoing
-  public Stream<ThesisInstitute<I, RV, RVT, RE, RET>> thesisInstitute_in(){
-    return inMany(graph().ThesisInstitute());
-  }
-  public Stream<Thesis<I, RV, RVT, RE, RET>> thesisInstitute_inV(){
-    return inManyV(graph().ThesisInstitute());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/InterPro.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/InterPro.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinInterPro;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/29/2014.
-*/
 public final class InterPro <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 InterPro<I, RV, RVT, RE, RET>,
@@ -24,27 +18,4 @@ I, RV, RVT, RE, RET
   public InterPro<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinInterPro
-  // ingoing
-  public Stream<ProteinInterPro<I, RV, RVT, RE, RET>> proteinInterPro_in(){
-    return inMany(graph().ProteinInterPro());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinInterPro_inV(){
-    return inManyV(graph().ProteinInterPro());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Isoform.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Isoform.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinIsoformInteraction;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/29/2014.
-*/
 public final class Isoform <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Isoform<I, RV, RVT, RE, RET>,
@@ -24,33 +18,4 @@ I, RV, RVT, RE, RET
   public Isoform<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String name() {
-    return get(type().name);
-  }
-  public String note() {
-    return get(type().note);
-  }
-  public String sequence() {
-    return get(type().sequence);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinIsoformInteraction
-  // ingoing
-  public Stream<ProteinIsoformInteraction<I, RV, RVT, RE, RET>> proteinIsoformInteraction_in(){
-    return inMany(graph().ProteinIsoformInteraction());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinIsoformInteraction_inV(){
-    return inManyV(graph().ProteinIsoformInteraction());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Journal.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Journal.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ArticleJournal;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Journal <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Journal<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public Journal<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // articleJournal
-  // ingoing
-  public Stream<ArticleJournal<I, RV, RVT, RE, RET>> articleJournal_in(){
-    return inMany(graph().ArticleJournal());
-  }
-  public Stream<Article<I, RV, RVT, RE, RET>> articleJournal_inV(){
-    return inManyV(graph().ArticleJournal());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Kegg.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Kegg.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinKegg;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Kegg <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Kegg<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public Kegg<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinKegg
-  // ingoing
-  public Stream<ProteinKegg<I, RV, RVT, RE, RET>> proteinKegg_in(){
-    return inMany(graph().ProteinKegg());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinKegg_inV(){
-    return inManyV(graph().ProteinKegg());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Keyword.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Keyword.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinKeyword;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/29/2014.
-*/
 public class Keyword <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Keyword<I, RV, RVT, RE, RET>,
@@ -24,27 +18,4 @@ I, RV, RVT, RE, RET
   public Keyword<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinKeyword
-  // ingoing
-  public Stream<ProteinKeyword<I, RV, RVT, RE, RET>> proteinKeyword_in(){
-    return inMany(graph().ProteinKeyword());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinKeyword_inV(){
-    return inManyV(graph().ProteinKeyword());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/OnlineArticle.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/OnlineArticle.java
@@ -1,15 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.OnlineArticleOnlineJournal;
-import com.bio4j.model.uniprot.edges.ReferenceOnlineArticle;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.Optional;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class OnlineArticle <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 OnlineArticle<I, RV, RVT, RE, RET>,
@@ -24,32 +17,5 @@ I, RV, RVT, RE, RET
   @Override
   public OnlineArticle<I, RV, RVT, RE, RET> self() {
     return this;
-  }
-
-  // properties
-  public String title() {
-    return get(type().title);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // referenceOnlineArticle
-  // ingoing
-  public ReferenceOnlineArticle<I, RV, RVT, RE, RET> referenceOnlineArticle_in(){
-    return inOne(graph().ReferenceOnlineArticle());
-  }
-  public Reference<I, RV, RVT, RE, RET> referenceOnlineArticle_inV(){
-    return inOneV(graph().ReferenceOnlineArticle());
-  }
-
-  // onlineArticleOnlineJournal
-  // outgoing
-  public Optional<OnlineArticleOnlineJournal<I, RV, RVT, RE, RET>> onlineArticleOnlineJournal_out(){
-    return outOneOptional(graph().OnlineArticleOnlineJournal());
-  }
-  public Optional<OnlineJournal<I, RV, RVT, RE, RET>> onlineArticleOnlineJournal_outV(){
-    return outOneOptionalV(graph().OnlineArticleOnlineJournal());
   }
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/OnlineJournal.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/OnlineJournal.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.OnlineArticleOnlineJournal;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class OnlineJournal <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 OnlineJournal<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public OnlineJournal<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // onlineArticleOnlineJournal
-  // ingoing
-  public Stream<OnlineArticleOnlineJournal<I, RV, RVT, RE, RET>> onlineArticleOnlineJournal_in(){
-    return inMany(graph().OnlineArticleOnlineJournal());
-  }
-  public Stream<OnlineArticle<I, RV, RVT, RE, RET>> onlineArticleOnlineJournal_inV(){
-    return inManyV(graph().OnlineArticleOnlineJournal());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/PIR.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/PIR.java
@@ -1,21 +1,15 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinPIR;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class PIR <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 PIR<I, RV, RVT, RE, RET>,
 UniProtGraph<I, RV, RVT, RE, RET>.PIRType,
 I, RV, RVT, RE, RET
 > {
-  
+
   public PIR(RV vertex, UniProtGraph<I, RV, RVT, RE, RET>.PIRType type) {
     super(vertex, type);
   }
@@ -24,25 +18,4 @@ I, RV, RVT, RE, RET
   public PIR<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String entryName() { return get(type().entryName);}
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinPIR
-  // ingoing
-  public Stream<ProteinPIR<I, RV, RVT, RE, RET>> proteinPIR_in(){
-    return inMany(graph().ProteinPIR());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinPIR_inV(){
-    return inManyV(graph().ProteinPIR());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Patent.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Patent.java
@@ -1,12 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ReferencePatent;
 import com.bio4j.angulillos.UntypedGraph;
 
-/**
-* @author <a href="mailto:ppareja@era7.com">Pablo Pareja Tobes</a>
-*/
 public final class Patent<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Patent<I, RV, RVT, RE, RET>,
@@ -21,26 +17,5 @@ I, RV, RVT, RE, RET
   @Override
   public Patent<I, RV, RVT, RE, RET> self() {
     return this;
-  }
-
-  // properties
-  public String title() {
-    return get(type().title);
-  }
-  public String number() {
-    return get(type().number);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // referencePatent
-  // ingoing
-  public ReferencePatent<I, RV, RVT, RE, RET> referencePatent_in(){
-    return inOne(graph().ReferencePatent());
-  }
-  public Reference<I, RV, RVT, RE, RET> referencePatent_inV(){
-    return inOneV(graph().ReferencePatent());
   }
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Person.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Person.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ReferenceAuthorPerson;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Person <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Person<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public Person<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // referenceAuthorPeron
-  // ingoing
-  public Stream<ReferenceAuthorPerson<I, RV, RVT, RE, RET>> referenceAuthorPerson_in(){
-    return inMany(graph().ReferenceAuthorPerson());
-  }
-  public Stream<Reference<I, RV, RVT, RE, RET>> referenceAuthorPerson_inV(){
-    return inManyV(graph().ReferenceAuthorPerson());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Pfam.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Pfam.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinPfam;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/29/2014.
-*/
 public class Pfam <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Pfam<I, RV, RVT, RE, RET>,
@@ -24,27 +18,4 @@ I, RV, RVT, RE, RET
   public Pfam<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinPfam
-  // ingoing
-  public Stream<ProteinPfam<I, RV, RVT, RE, RET>> proteinPfam_in(){
-    return inMany(graph().ProteinPfam());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinPfam_inV(){
-    return inManyV(graph().ProteinPfam());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Publisher.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Publisher.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.BookPublisher;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Publisher <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Publisher<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public Publisher<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // bookPublisher
-  // ingoing
-  public Stream<BookPublisher<I, RV, RVT, RE, RET>> bookPublisher_in(){
-    return inMany(graph().BookPublisher());
-  }
-  public Stream<Book<I, RV, RVT, RE, RET>> bookPublisher_inV(){
-    return inManyV(graph().BookPublisher());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Pubmed.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Pubmed.java
@@ -1,12 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ArticlePubmed;
 import com.bio4j.angulillos.UntypedGraph;
 
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Pubmed <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Pubmed<I, RV, RVT, RE, RET>,
@@ -22,24 +18,4 @@ I, RV, RVT, RE, RET
   public Pubmed<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // articlePubmed
-  // ingoing
-  public ArticlePubmed<I, RV, RVT, RE, RET> articlePubmed_in(){
-    return inOne(graph().ArticlePubmed());
-  }
-  public Article<I, RV, RVT, RE, RET> articlePubmed_inV(){
-    return inOneV(graph().ArticlePubmed());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/ReactomeTerm.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/ReactomeTerm.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinReactomeTerm;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class ReactomeTerm <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 ReactomeTerm<I, RV, RVT, RE, RET>,
@@ -24,27 +18,4 @@ I, RV, RVT, RE, RET
   public ReactomeTerm<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String pathwayName() {
-    return get(type().pathwayName);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinReactomeTerm
-  // ingoing
-  public Stream<ProteinReactomeTerm<I, RV, RVT, RE, RET>> proteinReactomeTerm_in(){
-    return inMany(graph().ProteinReactomeTerm());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinReactomeTerm_inV(){
-    return inManyV(graph().ProteinReactomeTerm());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/RefSeq.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/RefSeq.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinRefSeq;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class RefSeq <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 RefSeq<I, RV, RVT, RE, RET>,
@@ -24,27 +18,4 @@ I, RV, RVT, RE, RET
   public RefSeq<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-  public String nucleotideSequenceId() {
-    return get(type().nucleotideSequenceId);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinRefSeq
-  // ingoing
-  public Stream<ProteinRefSeq<I, RV, RVT, RE, RET>> proteinRefSeq_in(){
-    return inMany(graph().ProteinRefSeq());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinRefSeq_inV(){
-    return inManyV(graph().ProteinRefSeq());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Reference.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Reference.java
@@ -1,15 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.*;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.Optional;
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/29/2014.
-*/
 public final class Reference <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Reference<I, RV, RVT, RE, RET>,
@@ -25,60 +18,4 @@ I, RV, RVT, RE, RET
   public Reference<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String date() {
-    return get(type().date);
-  }
-  public String id(){ return get(type().id); }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinReference
-  // ingoing
-  public Stream<ProteinReference<I, RV, RVT, RE, RET>> proteinReference_in(){  return inMany(graph().ProteinReference());  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinReference_inV(){
-    return inManyV(graph().ProteinReference());
-  }
-  // referenceArticle
-  // outgoing
-  public Optional<ReferenceArticle<I, RV, RVT, RE, RET>> referenceArticle_out(){  return outOneOptional(graph().ReferenceArticle());  }
-  public Optional<Article<I, RV, RVT, RE, RET>> referenceArticle_outV(){  return outOneOptionalV(graph().ReferenceArticle());  }
-  // referenceBook
-  // outgoing
-  public Optional<ReferenceBook<I, RV, RVT, RE, RET>> referenceBook_out(){  return outOneOptional(graph().ReferenceBook());  }
-  public Optional<Book<I, RV, RVT, RE, RET>> referenceBook_outV(){  return outOneOptionalV(graph().ReferenceBook());  }
-  // referenceOnlineArticle
-  // outgoing
-  public Optional<ReferenceOnlineArticle<I, RV, RVT, RE, RET>> referenceOnlineArticle_out(){  return outOneOptional(graph().ReferenceOnlineArticle());  }
-  public Optional<OnlineArticle<I, RV, RVT, RE, RET>> referenceOnlineArticle_outV(){  return outOneOptionalV(graph().ReferenceOnlineArticle());  }
-  // referencePatent
-  // outgoing
-  public Optional<ReferencePatent<I, RV, RVT, RE, RET>> referencePatent_out(){  return outOneOptional(graph().ReferencePatent());  }
-  public Optional<Patent<I, RV, RVT, RE, RET>> referencePatent_outV(){  return outOneOptionalV(graph().ReferencePatent());  }
-  // referenceSubmission
-  // outgoing
-  public Optional<ReferenceSubmission<I, RV, RVT, RE, RET>> referenceSubmission_out(){  return outOneOptional(graph().ReferenceSubmission());  }
-  public Optional<Submission<I, RV, RVT, RE, RET>> referenceSubmission_outV(){  return outOneOptionalV(graph().ReferenceSubmission());  }
-  // referenceThesis
-  // outgoing
-  public Optional<ReferenceThesis<I, RV, RVT, RE, RET>> referenceThesis_out(){  return outOneOptional(graph().ReferenceThesis());  }
-  public Optional<Thesis<I, RV, RVT, RE, RET>> referenceThesis_outV(){  return outOneOptionalV(graph().ReferenceThesis());  }
-  // referenceUnpublishedObservation
-  // outgoing
-  public Optional<ReferenceUnpublishedObservation<I, RV, RVT, RE, RET>> referenceUnpublishedObservation_out(){  return outOneOptional(graph().ReferenceUnpublishedObservation());  }
-  public Optional<UnpublishedObservation<I, RV, RVT, RE, RET>> referenceUnpublishedObservation_outV(){  return outOneOptionalV(graph().ReferenceUnpublishedObservation());  }
-  // referenceAuthorConsortium
-  // outgoing
-  public Optional<Stream<ReferenceAuthorConsortium<I, RV, RVT, RE, RET>>> referenceAuthorConsortium_out(){  return outManyOptional(graph().ReferenceAuthorConsortium());  }
-  public Optional<Stream<Consortium<I, RV, RVT, RE, RET>>> referenceAuthorConsortium_outV(){  return outManyOptionalV(graph().ReferenceAuthorConsortium());  }
-  // referenceAuthorPerson
-  // outgoing
-  public Optional<Stream<ReferenceAuthorPerson<I, RV, RVT, RE, RET>>> referenceAuthorPerson_out(){  return outManyOptional(graph().ReferenceAuthorPerson());  }
-  public Optional<Stream<Person<I, RV, RVT, RE, RET>>> referenceAuthorPerson_outV(){  return outManyOptionalV(graph().ReferenceAuthorPerson());  }
-
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/SequenceCaution.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/SequenceCaution.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinSequenceCaution;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* @author <a href="mailto:ppareja@era7.com">Pablo Pareja Tobes</a>
-*/
 public final class SequenceCaution <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 SequenceCaution<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public SequenceCaution<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinSequenceCaution
-  // ingoing
-  public Stream<ProteinSequenceCaution<I, RV, RVT, RE, RET>> proteinSequenceCaution_in(){
-    return inMany(graph().ProteinSequenceCaution());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>>  proteinSequenceCaution_inV(){
-    return inManyV(graph().ProteinSequenceCaution());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/SubcellularLocation.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/SubcellularLocation.java
@@ -1,15 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinSubcellularLocation;
-import com.bio4j.model.uniprot.edges.SubcellularLocationParent;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class SubcellularLocation <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 SubcellularLocation<I, RV, RVT, RE, RET>,
@@ -25,42 +18,4 @@ I, RV, RVT, RE, RET
   public SubcellularLocation<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String name() {
-    return get(type().name);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinSubcellularLocation
-  // ingoing
-  public Stream<ProteinSubcellularLocation<I, RV, RVT, RE, RET>> proteinSubcellularLocation_in(){
-    return inMany(graph().ProteinSubcellularLocation());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinSubcellularLocation_inV(){
-    return inManyV(graph().ProteinSubcellularLocation());
-  }
-
-  // subcellularLocationParent
-  // ingoing
-  public Stream<SubcellularLocationParent<I, RV, RVT, RE, RET>> subcellularLocationParent_in(){
-    return inMany(graph().SubcellularLocationParent());
-  }
-  public Stream<SubcellularLocation<I, RV, RVT, RE, RET>> subcellularLocationParent_inV(){
-    return inManyV(graph().SubcellularLocationParent());
-  }
-
-  // subcellularLocationParent
-  // outgoing
-  public SubcellularLocationParent<I, RV, RVT, RE, RET> subcellularLocationParent_out(){
-    return outOne(graph().SubcellularLocationParent());
-  }
-  public SubcellularLocation<I, RV, RVT, RE, RET> subcellularLocationParent_outV(){
-    return outOneV(graph().SubcellularLocationParent());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Submission.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Submission.java
@@ -1,15 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ReferenceSubmission;
-import com.bio4j.model.uniprot.edges.SubmissionDB;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.Optional;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class Submission <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Submission<I, RV, RVT, RE, RET>,
@@ -25,27 +18,4 @@ I, RV, RVT, RE, RET
   public Submission<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String title() {
-    return get(type().title);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // submissionDB
-  // outgoing
-  public Optional<SubmissionDB<I, RV, RVT, RE, RET>> submissionDB_out(){
-    return outOneOptional(graph().SubmissionDB());
-  }
-  public Optional<DB<I, RV, RVT, RE, RET>> submissionDB_outV(){
-    return outOneOptionalV(graph().SubmissionDB());
-  }
-
-  // referenceSubmission
-  // ingoing
-  public ReferenceSubmission<I, RV, RVT, RE, RET> referenceSubmission_in(){   return inOne(graph().ReferenceSubmission());}
-  public Reference<I, RV, RVT, RE, RET> referenceSubmission_inV(){ return inOneV(graph().ReferenceSubmission());}
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/Thesis.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/Thesis.java
@@ -1,15 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ReferenceThesis;
-import com.bio4j.model.uniprot.edges.ThesisInstitute;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.Optional;
-
-/**
-* @author <a href="mailto:ppareja@era7.com">Pablo Pareja Tobes</a>
-*/
 public final class Thesis<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 Thesis<I, RV, RVT, RE, RET>,
@@ -24,31 +17,5 @@ I, RV, RVT, RE, RET
   @Override
   public Thesis<I, RV, RVT, RE, RET> self() {
     return this;
-  }
-
-  // properties
-  public String title() {
-    return get(type().title);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // referenceThesis
-  // ingoing
-  public ReferenceThesis<I, RV, RVT, RE, RET> referenceThesis_in(){
-    return inOne(graph().ReferenceThesis());
-  }
-  public Reference<I, RV, RVT, RE, RET> referenceThesis_inV(){
-    return inOneV(graph().ReferenceThesis());
-  }
-  // thesisInstitute
-  // outgoing
-  public Optional<ThesisInstitute<I, RV, RVT, RE, RET>> thesisInstitute_out(){
-    return outOneOptional(graph().ThesisInstitute());
-  }
-  public Optional<Institute<I, RV, RVT, RE, RET>> thesisInstitute_outV(){
-    return outOneOptionalV(graph().ThesisInstitute());
   }
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/UniGene.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/UniGene.java
@@ -1,14 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ProteinUniGene;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.stream.Stream;
-
-/**
-* Created by ppareja on 7/23/2014.
-*/
 public final class UniGene <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 UniGene<I, RV, RVT, RE, RET>,
@@ -24,24 +18,4 @@ I, RV, RVT, RE, RET
   public UniGene<I, RV, RVT, RE, RET> self() {
     return this;
   }
-
-  // properties
-  public String id() {
-    return get(type().id);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // proteinUniGene
-  // ingoing
-  public Stream<ProteinUniGene<I, RV, RVT, RE, RET>> proteinUniGene_in(){
-    return inMany(graph().ProteinUniGene());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> proteinUniGene_inV(){
-    return inManyV(graph().ProteinUniGene());
-  }
-
-
 }

--- a/src/main/java/com/bio4j/model/uniprot/vertices/UnpublishedObservation.java
+++ b/src/main/java/com/bio4j/model/uniprot/vertices/UnpublishedObservation.java
@@ -1,12 +1,8 @@
 package com.bio4j.model.uniprot.vertices;
 
 import com.bio4j.model.uniprot.UniProtGraph;
-import com.bio4j.model.uniprot.edges.ReferenceUnpublishedObservation;
 import com.bio4j.angulillos.UntypedGraph;
 
-/**
-* @author <a href="mailto:ppareja@era7.com">Pablo Pareja Tobes</a>
-*/
 public final class UnpublishedObservation<I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
 extends UniProtGraph.UniProtVertex<
 UnpublishedObservation<I, RV, RVT, RE, RET>,
@@ -21,23 +17,5 @@ I, RV, RVT, RE, RET
   @Override
   public UnpublishedObservation<I, RV, RVT, RE, RET> self() {
     return this;
-  }
-
-  // properties
-  public String scope() {
-    return get(type().scope);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-
-  // referenceUnpublishedObservation
-  // ingoing
-  public ReferenceUnpublishedObservation<I, RV, RVT, RE, RET> referenceUnpublishedObservation_in(){
-    return inOne(graph().ReferenceUnpublishedObservation());
-  }
-  public Reference<I, RV, RVT, RE, RET> referenceUnpublishedObservation_inV(){
-    return inOneV(graph().ReferenceUnpublishedObservation());
   }
 }

--- a/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef100Member.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef100Member.java
@@ -34,11 +34,6 @@ public final class UniRef100Member<I extends UntypedGraph<RV, RVT, RE, RET>, RV,
   super(edge, type);
   }
 
-  // properties
-  public String proteinAccession() {
-  return get(type().proteinAccession);
-  }
-
   @Override
   public UniRef100Member<I, RV, RVT, RE, RET> self() {
   return this;

--- a/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef100Representant.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef100Representant.java
@@ -34,11 +34,6 @@ public final class UniRef100Representant<I extends UntypedGraph<RV, RVT, RE, RET
   super(edge, type);
   }
 
-  // properties
-  public String proteinAccession() {
-  return get(type().proteinAccession);
-  }
-
   @Override
   public UniRef100Representant<I, RV, RVT, RE, RET> self() {
   return this;

--- a/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef50Member.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef50Member.java
@@ -34,11 +34,6 @@ public final class UniRef50Member<I extends UntypedGraph<RV, RVT, RE, RET>, RV, 
   super(edge, type);
   }
 
-  // properties
-  public String proteinAccession() {
-  return get(type().proteinAccession);
-  }
-
   @Override
   public UniRef50Member<I, RV, RVT, RE, RET> self() {
   return this;

--- a/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef50Representant.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef50Representant.java
@@ -34,11 +34,6 @@ public final class UniRef50Representant<I extends UntypedGraph<RV, RVT, RE, RET>
   super(edge, type);
   }
 
-  // properties
-  public String proteinAccession() {
-  return get(type().proteinAccession);
-  }
-
   @Override
   public UniRef50Representant<I, RV, RVT, RE, RET> self() {
   return this;

--- a/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef90Member.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef90Member.java
@@ -34,11 +34,6 @@ public final class UniRef90Member<I extends UntypedGraph<RV, RVT, RE, RET>, RV, 
   super(edge, type);
   }
 
-  // properties
-  public String proteinAccession() {
-  return get(type().proteinAccession);
-  }
-
   @Override
   public UniRef90Member<I, RV, RVT, RE, RET> self() {
   return this;

--- a/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef90Representant.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/edges/UniRef90Representant.java
@@ -34,11 +34,6 @@ public final class UniRef90Representant<I extends UntypedGraph<RV, RVT, RE, RET>
   super(edge, type);
   }
 
-  // properties
-  public String proteinAccession() {
-  return get(type().proteinAccession);
-  }
-
   @Override
   public UniRef90Representant<I, RV, RVT, RE, RET> self() {
   return this;

--- a/src/main/java/com/bio4j/model/uniref/vertices/UniRef100Cluster.java
+++ b/src/main/java/com/bio4j/model/uniref/vertices/UniRef100Cluster.java
@@ -1,17 +1,8 @@
 package com.bio4j.model.uniref.vertices;
 
-import com.bio4j.model.uniprot.vertices.Protein;
-import com.bio4j.model.uniprot_uniref.edges.UniRef100Member;
-import com.bio4j.model.uniprot_uniref.edges.UniRef100Representant;
 import com.bio4j.model.uniref.UniRefGraph;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-/**
- * Created by ppareja on 7/23/2014.
- */
 public final class UniRef100Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
   extends UniRefGraph.UniRefVertex<
   UniRef100Cluster<I, RV, RVT, RE, RET>,
@@ -27,42 +18,4 @@ public final class UniRef100Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, R
   public UniRef100Cluster<I, RV, RVT, RE, RET> self() {
   return this;
   }
-
-  // properties
-  public String id() {
-  return get(type().id);
-  }
-  public String name() {
-  return get(type().name);
-  }
-  public String updatedDate() {
-  return get(type().updatedDate);
-  }
-  public String representantAccession() { return get(type().representantAccession);}
-  public String[] members() { return get(type().members);}
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-  //uniRef100Representant
-  // ingoing
-  public UniRef100Representant<I, RV, RVT, RE, RET> uniRef100Representant_in(){
-  return inOne(graph().uniProtUniRefGraph().UniRef100Representant());
-  }
-  public Protein<I, RV, RVT, RE, RET> uniRef100Representant_inV(){
-  return inOneV(graph().uniProtUniRefGraph().UniRef100Representant());
-  }
-
-  //uniRef100Member
-  // ingoing
-  public Stream<UniRef100Member<I, RV, RVT, RE, RET>> uniRef100Member_in(){
-  return inMany(graph().uniProtUniRefGraph().UniRef100Member());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> uniRef100Member_inV(){
-  return inManyV(graph().uniProtUniRefGraph().UniRef100Member());
-  }
-
-
-
-
 }

--- a/src/main/java/com/bio4j/model/uniref/vertices/UniRef50Cluster.java
+++ b/src/main/java/com/bio4j/model/uniref/vertices/UniRef50Cluster.java
@@ -1,17 +1,8 @@
 package com.bio4j.model.uniref.vertices;
 
-import com.bio4j.model.uniprot.vertices.Protein;
-import com.bio4j.model.uniprot_uniref.edges.UniRef50Member;
-import com.bio4j.model.uniprot_uniref.edges.UniRef50Representant;
 import com.bio4j.model.uniref.UniRefGraph;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-/**
- * Created by ppareja on 7/23/2014.
- */
 public final class UniRef50Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
   extends UniRefGraph.UniRefVertex<
   UniRef50Cluster<I, RV, RVT, RE, RET>,
@@ -27,41 +18,4 @@ public final class UniRef50Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, RV
   public UniRef50Cluster<I, RV, RVT, RE, RET> self() {
   return this;
   }
-
-  // properties
-  public String id() {
-  return get(type().id);
-  }
-  public String name() {
-  return get(type().name);
-  }
-  public String updatedDate() {
-  return get(type().updatedDate);
-  }
-  public String representantAccession() { return get(type().representantAccession);}
-  public String[] members() { return get(type().members);}
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-  //uniRef50Representant
-  // ingoing
-  public UniRef50Representant<I, RV, RVT, RE, RET> uniRef50Representant_in(){
-  return inOne(graph().uniProtUniRefGraph().UniRef50Representant());
-  }
-  public Protein<I, RV, RVT, RE, RET> uniRef50Representant_inV(){
-  return inOneV(graph().uniProtUniRefGraph().UniRef50Representant());
-  }
-
-  //uniRef50Member
-  // ingoing
-  public Stream<UniRef50Member<I, RV, RVT, RE, RET>> uniRef50Member_in(){
-  return inMany(graph().uniProtUniRefGraph().UniRef50Member());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> uniRef50Member_inV(){
-  return inManyV(graph().uniProtUniRefGraph().UniRef50Member());
-  }
-
-
-
 }

--- a/src/main/java/com/bio4j/model/uniref/vertices/UniRef90Cluster.java
+++ b/src/main/java/com/bio4j/model/uniref/vertices/UniRef90Cluster.java
@@ -1,17 +1,8 @@
 package com.bio4j.model.uniref.vertices;
 
-import com.bio4j.model.uniprot.vertices.Protein;
-import com.bio4j.model.uniprot_uniref.edges.UniRef90Member;
-import com.bio4j.model.uniprot_uniref.edges.UniRef90Representant;
 import com.bio4j.model.uniref.UniRefGraph;
 import com.bio4j.angulillos.UntypedGraph;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-/**
- * Created by ppareja on 7/23/2014.
- */
 public final class UniRef90Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, RV, RVT, RE, RET>
   extends UniRefGraph.UniRefVertex<
   UniRef90Cluster<I, RV, RVT, RE, RET>,
@@ -27,42 +18,4 @@ public final class UniRef90Cluster <I extends UntypedGraph<RV, RVT, RE, RET>, RV
   public UniRef90Cluster<I, RV, RVT, RE, RET> self() {
   return this;
   }
-
-  // properties
-  public String id() {
-  return get(type().id);
-  }
-  public String name() {
-  return get(type().name);
-  }
-  public String updatedDate() {
-  return get(type().updatedDate);
-  }
-  public String representantAccession() { return get(type().representantAccession);}
-  public String[] members() { return get(type().members);}
-
-  //////////////////////////////////////////////////////////////////////////////////////////////
-
-  // relationships
-  //uniRef90Representant
-  // ingoing
-  public UniRef90Representant<I, RV, RVT, RE, RET> uniRef90Representant_in(){
-  return inOne(graph().uniProtUniRefGraph().UniRef90Representant());
-  }
-  public Protein<I, RV, RVT, RE, RET> uniRef90Representant_inV(){
-  return inOneV(graph().uniProtUniRefGraph().UniRef90Representant());
-  }
-
-  //uniRef90Member
-  // ingoing
-  public Stream<UniRef90Member<I, RV, RVT, RE, RET>> uniRef90Member_in(){
-  return inMany(graph().uniProtUniRefGraph().UniRef90Member());
-  }
-  public Stream<Protein<I, RV, RVT, RE, RET>> uniRef90Member_inV(){
-  return inManyV(graph().uniProtUniRefGraph().UniRef90Member());
-  }
-
-
-
-
 }


### PR DESCRIPTION
They only add indirection. Much better to use the angulillos API directly.