### PR TITLE
Remove graph dependencies

### DIFF
--- a/src/main/java/com/bio4j/model/enzymedb/EnzymeDBGraph.java
+++ b/src/main/java/com/bio4j/model/enzymedb/EnzymeDBGraph.java
@@ -1,7 +1,6 @@
 package com.bio4j.model.enzymedb;
 
-import com.bio4j.model.enzymedb.vertices.Enzyme;
-import com.bio4j.model.uniprot_enzymedb.UniProtEnzymeDBGraph;
+import com.bio4j.model.enzymedb.vertices.*;
 import com.bio4j.angulillos.*;
 
 /*
@@ -164,22 +163,6 @@ _TO DO_ explain this.
     I,RV,RVT,RE,RET
   >
   enzymeIdIndex();
-
-/*
-----
-*/
-
-/*
-
-## Graph extensions
-
-### Link enzymes with UniProt proteins
-
-You can extend the EnzymeDB graph with a graph adding an edge to UniProt proteins, representing _TO DO: What?_. See [UniProtEnzymeDBGraph](../uniprot_enzymedb/UniProtEnzymeDBGraph.java.md) for more.
-
-*/
-
-  public abstract UniProtEnzymeDBGraph<I,RV,RVT,RE,RET> uniProtEnzymeDBGraph();
 
 /*
 ----

--- a/src/main/java/com/bio4j/model/go/GoGraph.java
+++ b/src/main/java/com/bio4j/model/go/GoGraph.java
@@ -1,10 +1,7 @@
 package com.bio4j.model.go;
 
-import com.bio4j.model.go.vertices.GoSlims;
-import com.bio4j.model.go.vertices.GoTerm;
-import com.bio4j.model.go.vertices.SubOntologies;
+import com.bio4j.model.go.vertices.*;
 import com.bio4j.model.go.edges.*;
-import com.bio4j.model.uniprot_go.UniProtGoGraph;
 import com.bio4j.angulillos.*;
 
 /*
@@ -78,8 +75,6 @@ implements
   public GoGraph(I graph) { raw = graph; }
 
   public I raw() { return raw; }
-
-  public abstract UniProtGoGraph<I,RV,RVT,RE,RET> uniProtGoGraph();
 
   public abstract TypedVertexIndex.Unique <
   GoTerm<I,RV,RVT,RE,RET>,GoTermType,

--- a/src/main/java/com/bio4j/model/ncbiTaxonomy/NCBITaxonomyGraph.java
+++ b/src/main/java/com/bio4j/model/ncbiTaxonomy/NCBITaxonomyGraph.java
@@ -1,8 +1,7 @@
 package com.bio4j.model.ncbiTaxonomy;
 
-import com.bio4j.model.ncbiTaxonomy.vertices.NCBITaxon;
-import com.bio4j.model.ncbiTaxonomy.edges.NCBITaxonParent;
-import com.bio4j.model.uniprot_ncbiTaxonomy.UniProtNCBITaxonomyGraph;
+import com.bio4j.model.ncbiTaxonomy.vertices.*;
+import com.bio4j.model.ncbiTaxonomy.edges.*;
 import com.bio4j.angulillos.*;
 
 /*
@@ -70,12 +69,9 @@ public abstract class NCBITaxonomyGraph<
     >
   nCBITaxonIdIndex();
 
-  public abstract UniProtNCBITaxonomyGraph<I, RV, RVT, RE, RET> uniProtNCBITaxonomyGraph();
-
   // types
   // vertices
   public abstract NCBITaxonType NCBITaxon();
-
   // edges
   public abstract NCBITaxonParentType NCBITaxonParent();
 

--- a/src/main/java/com/bio4j/model/uniprot/UniProtGraph.java
+++ b/src/main/java/com/bio4j/model/uniprot/UniProtGraph.java
@@ -2,10 +2,6 @@ package com.bio4j.model.uniprot;
 
 import com.bio4j.model.uniprot.vertices.*;
 import com.bio4j.model.uniprot.edges.*;
-import com.bio4j.model.uniprot_enzymedb.UniProtEnzymeDBGraph;
-import com.bio4j.model.uniprot_go.UniProtGoGraph;
-import com.bio4j.model.uniprot_ncbiTaxonomy.UniProtNCBITaxonomyGraph;
-import com.bio4j.model.uniprot_uniref.UniProtUniRefGraph;
 import com.bio4j.angulillos.*;
 
 import java.util.Date;
@@ -405,11 +401,6 @@ I, RV, RVT, RE, RET
   public I raw(){
     return raw;
   }
-
-  public abstract UniProtUniRefGraph<I,RV,RVT,RE,RET> uniProtUniRefGraph();
-  public abstract UniProtGoGraph<I,RV,RVT,RE,RET> uniProtGoGraph();
-  public abstract UniProtEnzymeDBGraph<I,RV,RVT,RE,RET> uniProtEnzymeDBGraph();
-  public abstract UniProtNCBITaxonomyGraph<I,RV,RVT,RE,RET> uniProtNCBITaxonomyGraph();
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////
   // indices

--- a/src/main/java/com/bio4j/model/uniprot_enzymedb/UniProtEnzymeDBGraph.java
+++ b/src/main/java/com/bio4j/model/uniprot_enzymedb/UniProtEnzymeDBGraph.java
@@ -1,6 +1,5 @@
 package com.bio4j.model.uniprot_enzymedb;
 
-
 import com.bio4j.model.enzymedb.EnzymeDBGraph;
 import com.bio4j.model.enzymedb.vertices.Enzyme;
 import com.bio4j.model.uniprot.UniProtGraph;

--- a/src/main/java/com/bio4j/model/uniprot_go/UniProtGoGraph.java
+++ b/src/main/java/com/bio4j/model/uniprot_go/UniProtGoGraph.java
@@ -1,6 +1,5 @@
 package com.bio4j.model.uniprot_go;
 
-
 import com.bio4j.model.go.GoGraph;
 import com.bio4j.model.go.vertices.GoTerm;
 import com.bio4j.model.uniprot.UniProtGraph;
@@ -58,11 +57,11 @@ public abstract class UniProtGoGraph<
   extends
   UniProtGoEdgeType <
     // src
-    Protein<I, RV, RVT, RE, RET>, 
+    Protein<I, RV, RVT, RE, RET>,
     UniProtGraph<I, RV, RVT, RE, RET>.ProteinType,
     UniProtGraph<I, RV, RVT, RE, RET>,
     // edge
-    GoAnnotation<I, RV, RVT, RE, RET>, 
+    GoAnnotation<I, RV, RVT, RE, RET>,
     UniProtGoGraph<I, RV, RVT, RE, RET>.GoAnnotationType,
     // tgt
     GoTerm<I, RV, RVT, RE, RET>,
@@ -70,14 +69,14 @@ public abstract class UniProtGoGraph<
     GoGraph<I, RV, RVT, RE, RET>
   >
   implements
-  TypedEdge.Type.ManyToMany 
+  TypedEdge.Type.ManyToMany
   {
 
   public GoAnnotationType(RET raw) {
 
     super(
     UniProtGoGraph.this.uniProtGraph().Protein(),
-    raw, 
+    raw,
     UniProtGoGraph.this.goGraph().GoTerm()
     );
   }
@@ -194,7 +193,7 @@ public abstract class UniProtGoGraph<
     S, ST, SG,
     E, ET, UniProtGoGraph<I, RV, RVT, RE, RET>, I, RV, RVT, RE, RET,
     T, TT, TG
-  > 
+  >
   {
 
   private RE edge;

--- a/src/main/java/com/bio4j/model/uniprot_uniref/UniProtUniRefGraph.java
+++ b/src/main/java/com/bio4j/model/uniprot_uniref/UniProtUniRefGraph.java
@@ -1,14 +1,11 @@
 package com.bio4j.model.uniprot_uniref;
 
-
-import com.bio4j.angulillos.*;
 import com.bio4j.model.uniprot.UniProtGraph;
 import com.bio4j.model.uniprot.vertices.Protein;
+import com.bio4j.model.uniref.vertices.*;
 import com.bio4j.model.uniprot_uniref.edges.*;
 import com.bio4j.model.uniref.UniRefGraph;
-import com.bio4j.model.uniref.vertices.UniRef100Cluster;
-import com.bio4j.model.uniref.vertices.UniRef50Cluster;
-import com.bio4j.model.uniref.vertices.UniRef90Cluster;
+import com.bio4j.angulillos.*;
 
 /*
 

--- a/src/main/java/com/bio4j/model/uniref/UniRefGraph.java
+++ b/src/main/java/com/bio4j/model/uniref/UniRefGraph.java
@@ -1,9 +1,6 @@
 package com.bio4j.model.uniref;
 
-import com.bio4j.model.uniprot_uniref.UniProtUniRefGraph;
-import com.bio4j.model.uniref.vertices.UniRef100Cluster;
-import com.bio4j.model.uniref.vertices.UniRef50Cluster;
-import com.bio4j.model.uniref.vertices.UniRef90Cluster;
+import com.bio4j.model.uniref.vertices.*;
 import com.bio4j.angulillos.*;
 
 /*
@@ -55,8 +52,6 @@ public abstract class UniRefGraph<
     return raw;
   }
 
-  public abstract UniProtUniRefGraph<I, RV, RVT, RE, RET> uniProtUniRefGraph();
-
   //////////////////////////////////////////////////////////////////////////////////////////////////////////
   // indices
   public abstract TypedVertexIndex.Unique <
@@ -94,11 +89,9 @@ public abstract class UniRefGraph<
   // types
   //////////////////////////////////////////////////////////////////////////////////////////////////////////
   // vertices
-  public abstract UniRef50ClusterType UniRef50Cluster();
-
-  public abstract UniRef90ClusterType UniRef90Cluster();
-
-  public abstract UniRef100ClusterType UniRef100Cluster();
+  public abstract UniRef50ClusterType   UniRef50Cluster();
+  public abstract UniRef90ClusterType   UniRef90Cluster();
+  public abstract UniRef100ClusterType  UniRef100Cluster();
 
 
 
@@ -139,8 +132,8 @@ public abstract class UniRefGraph<
 
   public final class name
     extends
-    UniRefVertexProperty<UniRef50Cluster<I, RV, RVT, RE, RET>, UniRef50ClusterType, name, String> 
-  {  
+    UniRefVertexProperty<UniRef50Cluster<I, RV, RVT, RE, RET>, UniRef50ClusterType, name, String>
+  {
     public name() { super(UniRef50ClusterType.this); }
     public Class<String> valueClass() { return String.class; }
   }
@@ -190,14 +183,14 @@ public abstract class UniRefGraph<
   public UniRef90ClusterType value() { return graph().UniRef90Cluster(); }
 
   @Override
-  public UniRef90Cluster<I, RV, RVT, RE, RET> from(RV vertex) { 
+  public UniRef90Cluster<I, RV, RVT, RE, RET> from(RV vertex) {
 
     return new UniRef90Cluster<I, RV, RVT, RE, RET>(vertex, this);
   }
 
   public final class id
     extends
-    UniRefVertexProperty<UniRef90Cluster<I, RV, RVT, RE, RET>, UniRef90ClusterType, id, String> 
+    UniRefVertexProperty<UniRef90Cluster<I, RV, RVT, RE, RET>, UniRef90ClusterType, id, String>
   {
 
     public id() { super(UniRef90ClusterType.this); }
@@ -206,7 +199,7 @@ public abstract class UniRefGraph<
 
   public final class name
     extends
-    UniRefVertexProperty<UniRef90Cluster<I, RV, RVT, RE, RET>, UniRef90ClusterType, name, String> 
+    UniRefVertexProperty<UniRef90Cluster<I, RV, RVT, RE, RET>, UniRef90ClusterType, name, String>
   {
     public name() { super(UniRef90ClusterType.this); }
     public Class<String> valueClass() { return String.class; }
@@ -214,7 +207,7 @@ public abstract class UniRefGraph<
 
   public final class updatedDate
     extends
-    UniRefVertexProperty<UniRef90Cluster<I, RV, RVT, RE, RET>, UniRef90ClusterType, updatedDate, String> 
+    UniRefVertexProperty<UniRef90Cluster<I, RV, RVT, RE, RET>, UniRef90ClusterType, updatedDate, String>
   {
     public updatedDate() { super(UniRef90ClusterType.this); }
     public Class<String> valueClass() { return String.class; }
@@ -271,7 +264,7 @@ public abstract class UniRefGraph<
 
   public final class name
     extends
-    UniRefVertexProperty<UniRef100Cluster<I, RV, RVT, RE, RET>, UniRef100ClusterType, name, String> 
+    UniRefVertexProperty<UniRef100Cluster<I, RV, RVT, RE, RET>, UniRef100ClusterType, name, String>
   {
     public name() { super(UniRef100ClusterType.this); }
     public Class<String> valueClass() { return String.class; }
@@ -280,7 +273,7 @@ public abstract class UniRefGraph<
   public final class updatedDate
     extends
     UniRefVertexProperty<UniRef100Cluster<I, RV, RVT, RE, RET>, UniRef100ClusterType, updatedDate, String>
-  {  
+  {
     public updatedDate() { super(UniRef100ClusterType.this); }
     public Class<String> valueClass() { return String.class; }
   }


### PR DESCRIPTION
Graph dependencies arise when you have an edge going between vertices from possibly different graphs; an example is the organism assignment (an NCBI taxonomy vertex) of a UniProt protein. In this cases we are going to make such connections have a reference to the graphs being connected. All other notions of dependency are superfluous, being only needed for adding redundant methods to vertices and edges.