### PR TITLE
Add accession to canonical proteins

### DIFF
--- a/src/main/java/com/bio4j/model/UniProtGraph.java
+++ b/src/main/java/com/bio4j/model/UniProtGraph.java
@@ -40,6 +40,20 @@ public final class UniProtGraph<V,E> extends TypedGraph<UniProtGraph<V,E>,V,E> {
     }
 
     /*
+      #### Accession
+
+      Canonical isoforms (proteins) corresponding to an entry have an accession ID, which is the standard protein ID used almost everywhere. See http://www.uniprot.org/help/accession_numbers
+    */
+    public final Accession accession = new Accession();
+    public final class Accession extends Property<String> implements FromAtMostOne, ToAtMostOne {
+      private Accession() { super(String.class); }
+      public final Index index = new Index();
+      public final class Index extends UniqueIndex<Accession, String> {
+        private Index() { super(accession); }
+      }
+    }
+
+    /*
       #### Is canonical
 
       Whether this protein is the canonical protein of an entry.


### PR DESCRIPTION
A property with the entry-level accession, not the canonical isoform ID.