### PR TITLE
UniProt keyword categories should include "null"

### DIFF
--- a/src/main/java/com/bio4j/model/UniProtGraph.java
+++ b/src/main/java/com/bio4j/model/UniProtGraph.java
@@ -498,7 +498,8 @@ public final class UniProtGraph<V,E> extends TypedGraph<UniProtGraph<V,E>,V,E> {
     ligand,
     molecularFunction,
     PTM,
-    technicalTerm;
+    technicalTerm,
+    NULL;
   }
 
   /*


### PR DESCRIPTION
Believe it or not, that's a valid keyword ~~type~~ category.